### PR TITLE
fix: 썸네일 생성 Lambda 트리거 prefix 변경

### DIFF
--- a/modules/shared_resources/lambda.tf
+++ b/modules/shared_resources/lambda.tf
@@ -68,7 +68,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.thumbnail_generating_func.arn
     events              = ["s3:ObjectCreated:Put"]
-    filter_prefix       = "chat/images/"
+    filter_prefix       = "chat/files/"
   }
 
   depends_on = [

--- a/modules/shared_resources/src/thumbnail/index.js
+++ b/modules/shared_resources/src/thumbnail/index.js
@@ -14,10 +14,10 @@ export const handler = async (event) => {
 
         console.log(`Processing file: ${key} from bucket: ${bucket}`);
 
-        // chat/images/ 폴더의 이미지 파일만 처리
-        if (!key.startsWith('chat/images/')) {
-            console.log('Not a chat image, skipping');
-            return { statusCode: 200, body: 'Not a chat image' };
+        // chat/files/ 폴더의 이미지 파일만 처리
+        if (!key.startsWith('chat/files/')) {
+            console.log('Not a chat file, skipping');
+            return { statusCode: 200, body: 'Not a chat file' };
         }
 
         // 이미지 파일 확장자 확인


### PR DESCRIPTION
## 관련 이슈
- resolves: #26

## 작업 내용
- 썸네일 생성 Lambda의 S3 이벤트 트리거 prefix를 \chat/images/\에서 \chat/files/\로 변경했습니다.

## 특이 사항
- 기존 작업 트리에 다른 미커밋 변경이 있어, 이번 PR에는 Lambda trigger prefix 변경 1줄만 포함했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 파일 저장 위치 변경에 따른 섬네일 자동 생성 프로세스가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->