### PR TITLE
fix: 썸네일 이미지 포맷 유지

### DIFF
--- a/modules/shared_resources/src/thumbnail/index.js
+++ b/modules/shared_resources/src/thumbnail/index.js
@@ -57,23 +57,17 @@ async function createThumbnail(record) {
     const response = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
     const imageBuffer = await streamToBuffer(response.Body);
 
-    const thumbnailBuffer = await sharp(imageBuffer)
-        .resize(200, 200, {
-            fit: "inside",
-            withoutEnlargement: true,
-        })
-        .jpeg({ quality: 85 })
-        .toBuffer();
+    const thumbnailBuffer = await createThumbnailBuffer(imageBuffer, extension);
 
     const fileName = key.split("/").pop();
     const nameWithoutExt = fileName.slice(0, -extension.length);
-    const thumbnailKey = `${THUMBNAIL_PREFIX}${nameWithoutExt}_thumb.jpg`;
+    const thumbnailKey = `${THUMBNAIL_PREFIX}${nameWithoutExt}_thumb${extension}`;
 
     await s3.send(new PutObjectCommand({
         Bucket: bucket,
         Key: thumbnailKey,
         Body: thumbnailBuffer,
-        ContentType: "image/jpeg",
+        ContentType: getContentType(extension),
         Metadata: {
             "original-key": key,
             "generated-by": "thumbnail-lambda",
@@ -93,6 +87,39 @@ async function createThumbnail(record) {
 function getExtension(key) {
     const dotIndex = key.lastIndexOf(".");
     return dotIndex === -1 ? "" : key.slice(dotIndex).toLowerCase();
+}
+
+async function createThumbnailBuffer(imageBuffer, extension) {
+    const image = sharp(imageBuffer).resize(200, 200, {
+        fit: "inside",
+        withoutEnlargement: true,
+    });
+
+    switch (extension) {
+        case ".jpg":
+        case ".jpeg":
+            return image.jpeg({ quality: 85 }).toBuffer();
+        case ".png":
+            return image.png().toBuffer();
+        case ".webp":
+            return image.webp({ quality: 85 }).toBuffer();
+        default:
+            throw new Error(`Unsupported image extension: ${extension}`);
+    }
+}
+
+function getContentType(extension) {
+    switch (extension) {
+        case ".jpg":
+        case ".jpeg":
+            return "image/jpeg";
+        case ".png":
+            return "image/png";
+        case ".webp":
+            return "image/webp";
+        default:
+            throw new Error(`Unsupported image extension: ${extension}`);
+    }
 }
 
 async function streamToBuffer(stream) {


### PR DESCRIPTION
## 요약
- 생성되는 썸네일 키에 원본 이미지 확장자를 반영합니다.
- 썸네일 출력 인코딩을 원본 이미지 포맷에 맞춥니다.
- S3 Content-Type을 썸네일 포맷에 맞게 설정합니다.

## 테스트
- node --check modules\\shared_resources\\src\\thumbnail\\index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 썸네일이 이제 원본 이미지 형식(JPEG, PNG, WebP)을 유지합니다.
  * 썸네일 파일명이 원본 파일 확장자를 포함하도록 개선되었습니다.

* **개선사항**
  * S3 썸네일 생성 프로세스가 더욱 안정적으로 최적화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solid-connection/solid-connection-infra/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->