### PR TITLE
fix: SSH PEM 키 의존성 제거 → SSM RunCommand 방식으로 전환

### DIFF
--- a/environment/prod/main.tf
+++ b/environment/prod/main.tf
@@ -6,8 +6,8 @@ data "aws_vpc" "default" {
 module "prod_stack" {
   source = "../../modules/app_stack"
 
-  env_name          = "prod"
-  vpc_id            = data.aws_vpc.default.id
+  env_name = "prod"
+  vpc_id   = data.aws_vpc.default.id
 
   ami_id = var.ami_id
 
@@ -15,8 +15,8 @@ module "prod_stack" {
   ec2_iam_instance_profile = var.ec2_iam_instance_profile
 
   # 키페어 및 접속 허용
-  key_name          = var.key_name
-  
+  key_name = var.key_name
+
   # 인스턴스 스펙
   instance_type     = var.server_instance_type
   db_instance_class = var.db_instance_class
@@ -27,29 +27,26 @@ module "prod_stack" {
 
   # RDS 식별자 설정
   rds_identifier = var.rds_identifier
-  
+
   # DB 계정 정보
-  db_username       = var.db_root_username
-  db_password       = var.db_root_password
+  db_username = var.db_root_username
+  db_password = var.db_root_password
 
   # DB 엔진 및 암호화 설정
-  db_engine_version = var.db_engine_version             # MySQL 버전 지정
+  db_engine_version       = var.db_engine_version       # MySQL 버전 지정
   db_parameter_group_name = var.db_parameter_group_name # MySQL 파라미터 그룹 지정
-  kms_key_arn       = var.kms_key_arn                   # KMS ARN 변수 전달
+  kms_key_arn             = var.kms_key_arn             # KMS ARN 변수 전달
 
   # 추가 유저마다 다른 권한 부여
   additional_db_users = var.additional_db_users
 
   # Nginx 및 도메인 설정
-  domain_name = var.domain_name
-  cert_email  = var.cert_email
+  domain_name     = var.domain_name
+  cert_email      = var.cert_email
   nginx_conf_name = var.nginx_conf_name
 
-  # ssh key 경로 전달
-  ssh_key_path = var.ssh_key_path
-
   # Side Infra 관련 변수 전달
-  work_dir = var.work_dir
+  work_dir       = var.work_dir
   alloy_env_name = var.alloy_env_name
 
   redis_version          = var.redis_version

--- a/environment/prod/variables.tf
+++ b/environment/prod/variables.tf
@@ -99,11 +99,6 @@ variable "nginx_conf_name" {
   type        = string
 }
 
-variable "ssh_key_path" {
-  description = "Path to the SSH private key file for remote-exec"
-  type        = string
-}
-
 variable "work_dir" {
   description = "Working directory for the application"
   type        = string

--- a/environment/stage/main.tf
+++ b/environment/stage/main.tf
@@ -31,9 +31,6 @@ module "stage_stack" {
   cert_email      = var.cert_email
   nginx_conf_name = var.nginx_conf_name
 
-  # ssh key 경로 전달
-  ssh_key_path = var.ssh_key_path
-
   # Side Infra 관련 변수 전달
   work_dir       = var.work_dir
   alloy_env_name = var.alloy_env_name

--- a/environment/stage/variables.tf
+++ b/environment/stage/variables.tf
@@ -44,11 +44,6 @@ variable "nginx_conf_name" {
   type        = string
 }
 
-variable "ssh_key_path" {
-  description = "Path to the SSH private key file for remote-exec"
-  type        = string
-}
-
 variable "work_dir" {
   description = "Working directory for the application"
   type        = string

--- a/modules/app_stack/ec2.tf
+++ b/modules/app_stack/ec2.tf
@@ -55,7 +55,37 @@ resource "aws_instance" "api_server" {
   }
 }
 
-# 설정 및 컨테이너 실행
+locals {
+  nginx_script_b64 = base64encode(templatefile("${path.module}/scripts/nginx_setup.sh.tftpl", {
+    domain_name    = var.domain_name
+    email          = var.cert_email
+    conf_file_name = var.nginx_conf_name
+  }))
+
+  alloy_config = templatefile("${path.module}/../../config/side-infra/config.alloy.tftpl", {
+    loki_ip = data.aws_instance.monitoring_server.private_ip
+  })
+
+  side_infra_script_b64 = base64encode(templatefile("${path.module}/scripts/side_infra_setup.sh.tftpl", {
+    work_dir               = var.work_dir
+    alloy_env_name         = var.alloy_env_name
+    alloy_config_content   = local.alloy_config
+    redis_version          = var.redis_version
+    redis_exporter_version = var.redis_exporter_version
+    alloy_version          = var.alloy_version
+  }))
+
+  nginx_ssm_params = jsonencode({
+    commands         = ["cloud-init status --wait > /dev/null", "echo ${local.nginx_script_b64} | base64 -d | sudo bash"]
+    executionTimeout = ["3600"]
+  })
+
+  side_infra_ssm_params = jsonencode({
+    commands         = ["cloud-init status --wait > /dev/null", "echo ${local.side_infra_script_b64} | base64 -d | sudo bash"]
+    executionTimeout = ["3600"]
+  })
+}
+
 # [리소스 1] Nginx 설정 변경 감지 및 실행
 resource "null_resource" "update_nginx" {
   depends_on = [aws_instance.api_server]
@@ -68,30 +98,39 @@ resource "null_resource" "update_nginx" {
     }))
   }
 
-  connection {
-    type        = "ssh"
-    user        = "ubuntu"
-    host        = aws_instance.api_server.public_ip
-    private_key = file(var.ssh_key_path)
-  }
-
-  provisioner "file" {
-    content = templatefile("${path.module}/scripts/nginx_setup.sh.tftpl", {
-      domain_name    = var.domain_name
-      email          = var.cert_email
-      conf_file_name = var.nginx_conf_name
-    })
-    destination = "/tmp/update_nginx.sh"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait > /dev/null", # Docker 설치 대기
-      "chmod +x /tmp/update_nginx.sh",
-      "echo 'Running Updated Nginx Script...'",
-      "sudo /tmp/update_nginx.sh",
-      "rm /tmp/update_nginx.sh"
-    ]
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      INSTANCE_ID='${aws_instance.api_server.id}'
+      COMMAND_ID=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters '${local.nginx_ssm_params}' \
+        --output text \
+        --query "Command.CommandId")
+      ATTEMPTS=0
+      while [ "$ATTEMPTS" -lt 60 ]; do
+        STATUS=$(aws ssm get-command-invocation \
+          --command-id "$COMMAND_ID" \
+          --instance-id "$INSTANCE_ID" \
+          --query "Status" --output text 2>/dev/null || echo "Pending")
+        case "$STATUS" in
+          Success) exit 0 ;;
+          Failed|Cancelled|TimedOut|Undeliverable)
+            echo "SSM command $STATUS" >&2
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardErrorContent" --output text >&2
+            exit 1 ;;
+        esac
+        ATTEMPTS=$((ATTEMPTS + 1))
+        sleep 10
+      done
+      echo "SSM command timed out after 600s" >&2
+      exit 1
+    EOT
   }
 }
 
@@ -112,34 +151,38 @@ resource "null_resource" "update_side_infra" {
     }))
   }
 
-  connection {
-    type        = "ssh"
-    user        = "ubuntu"
-    host        = aws_instance.api_server.public_ip
-    private_key = file(var.ssh_key_path)
-  }
-
-  provisioner "file" {
-    content = templatefile("${path.module}/scripts/side_infra_setup.sh.tftpl", {
-      work_dir       = var.work_dir
-      alloy_env_name = var.alloy_env_name
-      alloy_config_content = templatefile("${path.module}/../../config/side-infra/config.alloy.tftpl", {
-        loki_ip = data.aws_instance.monitoring_server.private_ip
-      })
-      redis_version          = var.redis_version
-      redis_exporter_version = var.redis_exporter_version
-      alloy_version          = var.alloy_version
-    })
-    destination = "/tmp/update_side_infra.sh"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait > /dev/null", # Docker 설치 대기
-      "chmod +x /tmp/update_side_infra.sh",
-      "echo 'Running Updated Side Infra Script...'",
-      "sudo /tmp/update_side_infra.sh",
-      "rm /tmp/update_side_infra.sh"
-    ]
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      INSTANCE_ID='${aws_instance.api_server.id}'
+      COMMAND_ID=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters '${local.side_infra_ssm_params}' \
+        --output text \
+        --query "Command.CommandId")
+      ATTEMPTS=0
+      while [ "$ATTEMPTS" -lt 60 ]; do
+        STATUS=$(aws ssm get-command-invocation \
+          --command-id "$COMMAND_ID" \
+          --instance-id "$INSTANCE_ID" \
+          --query "Status" --output text 2>/dev/null || echo "Pending")
+        case "$STATUS" in
+          Success) exit 0 ;;
+          Failed|Cancelled|TimedOut|Undeliverable)
+            echo "SSM command $STATUS" >&2
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardErrorContent" --output text >&2
+            exit 1 ;;
+        esac
+        ATTEMPTS=$((ATTEMPTS + 1))
+        sleep 10
+      done
+      echo "SSM command timed out after 600s" >&2
+      exit 1
+    EOT
   }
 }

--- a/modules/app_stack/ec2.tf
+++ b/modules/app_stack/ec2.tf
@@ -110,7 +110,7 @@ resource "null_resource" "update_nginx" {
         --output text \
         --query "Command.CommandId")
       ATTEMPTS=0
-      while [ "$ATTEMPTS" -lt 60 ]; do
+      while [ "$ATTEMPTS" -lt 360 ]; do
         STATUS=$(aws ssm get-command-invocation \
           --command-id "$COMMAND_ID" \
           --instance-id "$INSTANCE_ID" \
@@ -128,7 +128,7 @@ resource "null_resource" "update_nginx" {
         ATTEMPTS=$((ATTEMPTS + 1))
         sleep 10
       done
-      echo "SSM command timed out after 600s" >&2
+      echo "SSM command timed out after 3600s" >&2
       exit 1
     EOT
   }
@@ -163,7 +163,7 @@ resource "null_resource" "update_side_infra" {
         --output text \
         --query "Command.CommandId")
       ATTEMPTS=0
-      while [ "$ATTEMPTS" -lt 60 ]; do
+      while [ "$ATTEMPTS" -lt 360 ]; do
         STATUS=$(aws ssm get-command-invocation \
           --command-id "$COMMAND_ID" \
           --instance-id "$INSTANCE_ID" \
@@ -181,7 +181,7 @@ resource "null_resource" "update_side_infra" {
         ATTEMPTS=$((ATTEMPTS + 1))
         sleep 10
       done
-      echo "SSM command timed out after 600s" >&2
+      echo "SSM command timed out after 3600s" >&2
       exit 1
     EOT
   }

--- a/modules/app_stack/rds.tf
+++ b/modules/app_stack/rds.tf
@@ -2,16 +2,16 @@
 resource "aws_db_instance" "default" {
   count = var.enable_rds ? 1 : 0
 
-  identifier            = var.rds_identifier
-  allocated_storage     = 20
-  engine                = "mysql"
-  engine_version        = var.db_engine_version
-  instance_class        = var.db_instance_class
-  username              = var.db_username
-  password              = var.db_password
-  parameter_group_name  = var.db_parameter_group_name
-  copy_tags_to_snapshot = true
-  skip_final_snapshot   = true
+  identifier             = var.rds_identifier
+  allocated_storage      = 20
+  engine                 = "mysql"
+  engine_version         = var.db_engine_version
+  instance_class         = var.db_instance_class
+  username               = var.db_username
+  password               = var.db_password
+  parameter_group_name   = var.db_parameter_group_name
+  copy_tags_to_snapshot  = true
+  skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.db_sg[count.index].id]
 
   storage_encrypted = true

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -124,12 +124,6 @@ variable "nginx_conf_name" {
   type        = string
 }
 
-# [Remote SSH용 변수]
-variable "ssh_key_path" {
-  description = "Path to the SSH private key file for remote-exec"
-  type        = string
-}
-
 # [Side Infrastructure 관련 변수]
 variable "work_dir" {
   description = "Working directory for the application"


### PR DESCRIPTION
## 관련 이슈

- resolves: #41

## 작업 내용

`null_resource`의 EC2 원격 실행 방식을 SSH + PEM 키에서 **AWS SSM RunCommand**로 전환합니다.

**변경 파일**: `modules/app_stack/ec2.tf`, `modules/app_stack/variables.tf`, `environment/prod/main.tf`, `environment/prod/variables.tf`, `environment/stage/main.tf`, `environment/stage/variables.tf`

- `null_resource.update_nginx`, `null_resource.update_side_infra` 두 리소스의 SSH `connection` 블록 및 `file` / `remote-exec` provisioner 제거
- `local-exec` provisioner로 교체 — `aws ssm send-command`(AWS-RunShellScript)로 스크립트 전송 및 실행
- 스크립트 내용은 `base64encode(templatefile(...))` 후 EC2에서 `base64 -d | sudo bash`로 실행
- SSM 명령 완료를 10초 간격 폴링(최대 3600초)으로 대기하며, 실패 시 `StandardErrorContent` 출력 후 종료
- `locals` 블록을 단계별로 분리 (`alloy_config` → `*_script_b64` → `*_ssm_params`) 하여 가독성 확보
- `var.ssh_key_path` 변수 전 계층(모듈, prod, stage)에서 제거

## 특이 사항

- **근본 원인**: GitHub Actions 러너에 PEM 키 파일(`../../solid-connection-server-2.pem`)이 존재하지 않아 `file()` 함수 자체가 실패. PR #37 머지 시 `null_resource.update_nginx`의 `triggers.script_hash`가 변경되어 처음 표면화됨
- **IAM 변경 불필요**: `aws ssm send-command`는 GitHub Actions 러너(OIDC role)가 호출하며, Apply role에 연결된 `GitHubActionsTerraformInfraPolicy`에 `ssm:SendCommand` / `ssm:GetCommandInvocation`이 이미 포함되어 있음. EC2 SSM Agent 수신 측은 bootstrap에서 `AmazonSSMManagedInstanceCore`가 이미 부착되어 있음
- `key_name`(AWS Key Pair 등록명)은 EC2 인스턴스 생성 시 필요하므로 유지, PEM 파일 경로(`ssh_key_path`)만 제거

## 리뷰 요구사항 (선택)

- SSM RunCommand 폴링 로직(10초 간격 × 360회 = 최대 3600초)이 nginx 초기 설치(certbot 포함) 및 side infra 설정에 충분한지 확인 부탁드립니다