### PR TITLE
refactor: 크롤링 봇에 대한 요청 차단 nginx 로직 추가

### DIFF
--- a/modules/app_stack/scripts/nginx_setup.sh.tftpl
+++ b/modules/app_stack/scripts/nginx_setup.sh.tftpl
@@ -49,6 +49,24 @@ map \$http_upgrade \$connection_upgrade {
     ''      '';
 }
 
+# 1차 차단: 도메인과 일치하지 않는 요청 차단 (IP 직접 접근, 알 수 없는 Host 헤더)
+# 응답 없이 연결을 즉시 종료하여 봇이 서버 존재를 인식하지 못하게 함
+server {
+    listen 80 default_server;
+    server_name _;
+    return 444;
+}
+
+server {
+    listen 443 ssl default_server;
+    server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+
+    return 444;
+}
+
 server {
     listen 80;
     server_name $DOMAIN;
@@ -73,6 +91,11 @@ server {
     ssl_session_timeout 10m;
     ssl_stapling on;
     ssl_stapling_verify on;
+
+    # 2차 차단: 취약점 탐색용 정적 파일 확장자 요청 차단
+    location ~* \.(php|asp|aspx|jsp|cgi|env|git|sql|bak|backup|config|ini|log|sh|xml|txt|html|htm)$ {
+        return 444;
+    }
 
     location / {
         proxy_pass http://app_backend;

--- a/modules/app_stack/scripts/nginx_setup.sh.tftpl
+++ b/modules/app_stack/scripts/nginx_setup.sh.tftpl
@@ -93,7 +93,13 @@ server {
     ssl_stapling_verify on;
 
     # 2차 차단: 취약점 탐색용 정적 파일 확장자 요청 차단
-    location ~* \.(php|asp|aspx|jsp|cgi|env|git|sql|bak|backup|config|ini|log|sh|xml|txt|html|htm)$ {
+    # ($|[/?]) 로 확장자 뒤에 /path 또는 ?query 가 붙는 우회 패턴도 차단
+    location ~* \.(php|asp|aspx|jsp|cgi|sql|bak|backup|config|ini|log|sh|xml|txt|html|htm)($|[/?]) {
+        return 444;
+    }
+
+    # .env, .env.production, .git 등 dotfile 변형 차단
+    location ~* (^|/)\.(env|git) {
         return 444;
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #21

## 작업 내용

크롤링 봇의 취약점 탐색 요청을 Nginx 수준에서 차단하여 서버 로그 오염을 방지합니다.

**변경 파일**: `modules/app_stack/scripts/nginx_setup.sh.tftpl`

**1차 차단 — IP 직접 접근 및 알 수 없는 Host 헤더 차단**

`default_server` 블록을 80/443 포트에 추가하여 도메인과 일치하지 않는 모든 요청을 444로 차단합니다.

- IP 직접 접근(예: `http://1.2.3.4/`)
- 등록되지 않은 Host 헤더를 사용하는 요청

444는 응답 body 없이 연결을 즉시 종료하는 nginx 전용 코드로, 봇 입장에서 포트가 닫힌 것처럼 인식됩니다.

**2차 차단 — 취약점 탐색용 정적 파일 확장자 요청 차단**

Spring Boot API 서버에 도달할 이유가 없는 정적 파일 확장자 요청을 location 블록으로 차단합니다.

차단 대상: `.php` `.asp` `.aspx` `.jsp` `.cgi` `.env` `.git` `.sql` `.bak` `.backup` `.config` `.ini` `.log` `.sh` `.xml` `.txt` `.html` `.htm`

## 특이 사항

- prod, stage 두 환경 모두 `terraform plan` 검증 완료 — `null_resource.update_nginx` 1개 replace만 발생, 다른 리소스 변경 없음
- `upstream.conf`에 `if [ ! -f ]` 가드가 있어 재프로비저닝 시에도 현재 Blue/Green 슬롯이 유지됨

## 리뷰 요구사항 (선택)

- 2차 차단 확장자 목록(`.txt`, `.html`, `.xml` 등)이 서비스 운영 상 문제없는지 프론트 담당자 확인이 필요합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안 개선

* **버그 수정**
  * Nginx 서버 설정에 보안 차단 기능 추가됨
  * Host 미일치 요청에 대한 연결 차단 구성 추가
  * 취약점 스캔 및 악성 파일 확장자 요청 차단 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->