### PR TITLE
refactor: 서브모듈 포인터 변경 시 terraform plan/apply 실행되도록 경로 감지 기준 수정

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -35,25 +35,22 @@ jobs:
             global:
               - 'environment/global/**'
               - 'modules/shared_resources/**'
-              - 'config/secrets/shared_resources.tfvars'
+              - 'config/secrets'
             prod:
               - 'environment/prod/**'
               - 'modules/app_stack/**'
               - 'modules/common/**'
-              - 'config/secrets/prod.tfvars'
-              - 'config/secrets/app_stack.tfvars'
+              - 'config/secrets'
             stage:
               - 'environment/stage/**'
               - 'modules/app_stack/**'
               - 'modules/common/**'
-              - 'config/secrets/stage.tfvars'
-              - 'config/secrets/app_stack.tfvars'
+              - 'config/secrets'
             monitoring:
               - 'environment/monitoring/**'
               - 'modules/monitoring_stack/**'
               - 'modules/common/**'
-              - 'config/secrets/monitoring.tfvars'
-              - 'config/secrets/monitoring_stack.tfvars'
+              - 'config/secrets'
 
   apply-bootstrap:
     needs: detect-changes

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -36,25 +36,22 @@ jobs:
             global:
               - 'environment/global/**'
               - 'modules/shared_resources/**'
-              - 'config/secrets/shared_resources.tfvars'
+              - 'config/secrets'
             prod:
               - 'environment/prod/**'
               - 'modules/app_stack/**'
               - 'modules/common/**'
-              - 'config/secrets/prod.tfvars'
-              - 'config/secrets/app_stack.tfvars'
+              - 'config/secrets'
             stage:
               - 'environment/stage/**'
               - 'modules/app_stack/**'
               - 'modules/common/**'
-              - 'config/secrets/stage.tfvars'
-              - 'config/secrets/app_stack.tfvars'
+              - 'config/secrets'
             monitoring:
               - 'environment/monitoring/**'
               - 'modules/monitoring_stack/**'
               - 'modules/common/**'
-              - 'config/secrets/monitoring.tfvars'
-              - 'config/secrets/monitoring_stack.tfvars'
+              - 'config/secrets'
 
   plan-bootstrap:
     needs: detect-changes


### PR DESCRIPTION
## 관련 이슈

- resolves: #46

## 작업 내용

`dorny/paths-filter`의 감지 경로를 수정하여 `config/secrets` 서브모듈 포인터 변경 시에도 terraform plan/apply가 실행되도록 합니다.

**변경 파일**: `.github/workflows/terraform-plan.yml`, `.github/workflows/terraform-apply.yml`

**AS-IS**
- 각 filter group에 `config/secrets/app_stack.tfvars`, `config/secrets/prod.tfvars` 등 서브모듈 내부 파일 경로를 명시
- 서브모듈 내부 파일은 인프라 레포 git diff에 나타나지 않아 실제로 감지되지 않았음 (비동작 설정)
- 서브모듈 포인터만 변경되는 PR에서 plan/apply가 스킵됨

**TO-BE**
- 서브모듈 내부 파일 경로를 모두 제거하고 `config/secrets`(서브모듈 포인터) 하나로 통일
- 서브모듈 포인터 변경 시 해당 환경의 plan/apply가 실행됨
- 서브모듈 내 구체적 파일명이 워크플로우에 노출되지 않음

## 특이 사항

- 기존 `config/secrets/*.tfvars` 경로는 서브모듈 특성상 인프라 레포 diff에 나타나지 않아 원래부터 동작하지 않던 설정이었음
- `config/secrets` 포인터는 서브모듈 내 어떤 파일이 변경되든 항상 함께 업데이트되므로 감지 기준으로 충분함

## 리뷰 요구사항 (선택)

- `config/secrets` 하나로 모든 환경 filter를 커버하는 것이 의도에 맞는지 확인 부탁드립니다