### PR TITLE
feat: Prod DB EC2 리소스 추가

### DIFF
--- a/environment/prod/main.tf
+++ b/environment/prod/main.tf
@@ -21,6 +21,11 @@ module "prod_stack" {
   instance_type     = var.server_instance_type
   db_instance_class = var.db_instance_class
 
+  # DB EC2 설정
+  enable_db_ec2    = true
+  db_instance_type = var.db_ec2_instance_type
+  db_ami_id        = var.db_ec2_ami_id
+
   # 보안 그룹 규칙
   api_ingress_rules = var.api_ingress_rules
   db_ingress_rules  = var.db_ingress_rules

--- a/environment/prod/main.tf
+++ b/environment/prod/main.tf
@@ -25,6 +25,7 @@ module "prod_stack" {
   enable_db_ec2    = true
   db_instance_type = var.db_ec2_instance_type
   db_ami_id        = var.db_ec2_ami_id
+  db_subnet_id     = var.db_ec2_subnet_id
 
   # 보안 그룹 규칙
   api_ingress_rules = var.api_ingress_rules

--- a/environment/prod/variables.tf
+++ b/environment/prod/variables.tf
@@ -28,6 +28,11 @@ variable "db_ec2_ami_id" {
   type        = string
 }
 
+variable "db_ec2_subnet_id" {
+  description = "DB EC2를 배치할 Private Subnet ID"
+  type        = string
+}
+
 variable "api_ingress_rules" {
   description = "List of ingress rules for API Server"
   type = list(object({

--- a/environment/prod/variables.tf
+++ b/environment/prod/variables.tf
@@ -18,6 +18,16 @@ variable "db_instance_class" {
   type        = string
 }
 
+variable "db_ec2_instance_type" {
+  description = "DB EC2 인스턴스 타입"
+  type        = string
+}
+
+variable "db_ec2_ami_id" {
+  description = "DB EC2에 사용할 커스텀 AMI ID"
+  type        = string
+}
+
 variable "api_ingress_rules" {
   description = "List of ingress rules for API Server"
   type = list(object({

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -14,22 +14,6 @@ data "cloudinit_config" "db_init" {
   }
 }
 
-locals {
-  mysql_tuning_config_b64 = base64encode(file("${path.module}/templates/mysql_tuning.cnf"))
-
-  mysql_tuning_ssm_params = jsonencode({
-    commands = [
-      "cloud-init status --wait > /dev/null",
-      "sudo mkdir -p /etc/mysql/conf.d",
-      "echo ${local.mysql_tuning_config_b64} | base64 -d | sudo tee /etc/mysql/conf.d/tuning.cnf > /dev/null",
-      "sudo chmod 644 /etc/mysql/conf.d/tuning.cnf",
-      "sudo docker restart mysql-server",
-      "for i in $(seq 1 30); do if sudo docker exec mysql-server mysqladmin ping --silent >/dev/null 2>&1; then exit 0; fi; sleep 2; done; sudo docker logs --tail 100 mysql-server >&2; exit 1",
-    ]
-    executionTimeout = ["600"]
-  })
-}
-
 resource "aws_instance" "db_server" {
   count = var.enable_db_ec2 ? 1 : 0
 
@@ -69,50 +53,5 @@ resource "aws_instance" "db_server" {
       user_data_replace_on_change,
       key_name,
     ]
-  }
-}
-
-resource "null_resource" "update_mysql_tuning" {
-  count      = var.enable_db_ec2 ? 1 : 0
-  depends_on = [aws_instance.db_server]
-
-  triggers = {
-    config_hash = sha256(file("${path.module}/templates/mysql_tuning.cnf"))
-    instance_id = aws_instance.db_server[count.index].id
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["bash", "-c"]
-    command     = <<-EOT
-      set -euo pipefail
-      INSTANCE_ID='${aws_instance.db_server[count.index].id}'
-      COMMAND_ID=$(aws ssm send-command \
-        --instance-ids "$INSTANCE_ID" \
-        --document-name "AWS-RunShellScript" \
-        --parameters '${local.mysql_tuning_ssm_params}' \
-        --output text \
-        --query "Command.CommandId")
-      ATTEMPTS=0
-      while [ "$ATTEMPTS" -lt 60 ]; do
-        STATUS=$(aws ssm get-command-invocation \
-          --command-id "$COMMAND_ID" \
-          --instance-id "$INSTANCE_ID" \
-          --query "Status" --output text 2>/dev/null || echo "Pending")
-        case "$STATUS" in
-          Success) exit 0 ;;
-          Failed|Cancelled|TimedOut|Undeliverable)
-            echo "SSM command $STATUS" >&2
-            aws ssm get-command-invocation \
-              --command-id "$COMMAND_ID" \
-              --instance-id "$INSTANCE_ID" \
-              --query "StandardErrorContent" --output text >&2
-            exit 1 ;;
-        esac
-        ATTEMPTS=$((ATTEMPTS + 1))
-        sleep 10
-      done
-      echo "SSM command timed out after 600s" >&2
-      exit 1
-    EOT
   }
 }

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -1,0 +1,118 @@
+data "cloudinit_config" "db_init" {
+  count         = var.enable_db_ec2 ? 1 : 0
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    content = templatefile("${path.module}/scripts/mysql_setup.sh.tftpl", {
+      db_root_username_b64 = base64encode(var.db_username)
+      db_root_password_b64 = base64encode(var.db_password)
+      mysql_config_content = file("${path.module}/templates/mysql_tuning.cnf")
+    })
+    filename = "mysql_setup.sh"
+  }
+}
+
+locals {
+  mysql_tuning_config_b64 = base64encode(file("${path.module}/templates/mysql_tuning.cnf"))
+
+  mysql_tuning_ssm_params = jsonencode({
+    commands = [
+      "cloud-init status --wait > /dev/null",
+      "sudo mkdir -p /etc/mysql/conf.d",
+      "echo ${local.mysql_tuning_config_b64} | base64 -d | sudo tee /etc/mysql/conf.d/tuning.cnf > /dev/null",
+      "sudo chmod 644 /etc/mysql/conf.d/tuning.cnf",
+      "sudo docker restart mysql-server",
+      "for i in $(seq 1 30); do if sudo docker exec mysql-server mysqladmin ping --silent >/dev/null 2>&1; then exit 0; fi; sleep 2; done; sudo docker logs --tail 100 mysql-server >&2; exit 1",
+    ]
+    executionTimeout = ["600"]
+  })
+}
+
+resource "aws_instance" "db_server" {
+  count = var.enable_db_ec2 ? 1 : 0
+
+  ami           = var.db_ami_id
+  instance_type = var.db_instance_type
+
+  vpc_security_group_ids      = [aws_security_group.db_ec2_sg[count.index].id]
+  associate_public_ip_address = false
+  iam_instance_profile        = var.ec2_iam_instance_profile
+  key_name                    = var.key_name
+
+  user_data_base64 = data.cloudinit_config.db_init[count.index].rendered
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "solid-connection-db-mysql-${var.env_name}"
+  }
+
+  user_data_replace_on_change = false
+
+  lifecycle {
+    ignore_changes = [
+      user_data,
+      user_data_base64,
+      user_data_replace_on_change,
+      key_name,
+    ]
+  }
+}
+
+resource "null_resource" "update_mysql_tuning" {
+  count      = var.enable_db_ec2 ? 1 : 0
+  depends_on = [aws_instance.db_server]
+
+  triggers = {
+    config_hash = sha256(file("${path.module}/templates/mysql_tuning.cnf"))
+    instance_id = aws_instance.db_server[count.index].id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      INSTANCE_ID='${aws_instance.db_server[count.index].id}'
+      COMMAND_ID=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters '${local.mysql_tuning_ssm_params}' \
+        --output text \
+        --query "Command.CommandId")
+      ATTEMPTS=0
+      while [ "$ATTEMPTS" -lt 60 ]; do
+        STATUS=$(aws ssm get-command-invocation \
+          --command-id "$COMMAND_ID" \
+          --instance-id "$INSTANCE_ID" \
+          --query "Status" --output text 2>/dev/null || echo "Pending")
+        case "$STATUS" in
+          Success) exit 0 ;;
+          Failed|Cancelled|TimedOut|Undeliverable)
+            echo "SSM command $STATUS" >&2
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardErrorContent" --output text >&2
+            exit 1 ;;
+        esac
+        ATTEMPTS=$((ATTEMPTS + 1))
+        sleep 10
+      done
+      echo "SSM command timed out after 600s" >&2
+      exit 1
+    EOT
+  }
+}

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -19,6 +19,7 @@ resource "aws_instance" "db_server" {
 
   ami           = var.db_ami_id
   instance_type = var.db_instance_type
+  subnet_id     = var.db_subnet_id
 
   vpc_security_group_ids      = [aws_security_group.db_ec2_sg[count.index].id]
   associate_public_ip_address = false

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "db_server" {
   }
 
   root_block_device {
-    volume_size           = 20
+    volume_size           = 8
     volume_type           = "gp3"
     encrypted             = true
     delete_on_termination = true

--- a/modules/app_stack/output.tf
+++ b/modules/app_stack/output.tf
@@ -1,0 +1,9 @@
+output "db_server_private_ip" {
+  description = "DB EC2 서버 private IP"
+  value       = try(aws_instance.db_server[0].private_ip, null)
+}
+
+output "db_server_instance_id" {
+  description = "DB EC2 서버 인스턴스 ID"
+  value       = try(aws_instance.db_server[0].id, null)
+}

--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+DB_ROOT_USER="$(printf '%s' '${db_root_username_b64}' | base64 -d)"
+DB_ROOT_PASS="$(printf '%s' '${db_root_password_b64}' | base64 -d)"
+
+mysql_escape() {
+  local value="$1"
+  value="$${value//\\/\\\\}"
+  value="$${value//\'/\\\'}"
+  printf '%s' "$value"
+}
+
+DB_ROOT_USER_SQL="$(mysql_escape "$DB_ROOT_USER")"
+DB_ROOT_PASS_SQL="$(mysql_escape "$DB_ROOT_PASS")"
+
+command -v docker >/dev/null
+systemctl enable --now docker
+docker image inspect mysql:8.4 >/dev/null
+
+mkdir -p /var/lib/mysql
+chown -R 999:999 /var/lib/mysql
+chmod 750 /var/lib/mysql
+
+mkdir -p /etc/mysql/conf.d
+cat > /etc/mysql/conf.d/tuning.cnf <<'CNFEOF'
+${mysql_config_content}
+CNFEOF
+chmod 644 /etc/mysql/conf.d/tuning.cnf
+
+docker rm -f mysql-server 2>/dev/null || true
+
+docker run -d \
+  --name mysql-server \
+  --restart always \
+  -p 3306:3306 \
+  -v /var/lib/mysql:/var/lib/mysql \
+  -v /etc/mysql/conf.d:/etc/mysql/conf.d \
+  -e MYSQL_ROOT_PASSWORD="$DB_ROOT_PASS" \
+  mysql:8.4
+
+for i in $(seq 1 30); do
+  if docker exec mysql-server mysqladmin ping -uroot -p"$DB_ROOT_PASS" 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+docker exec -i mysql-server mysql -uroot -p"$DB_ROOT_PASS" <<SQLEOF
+CREATE USER IF NOT EXISTS '$DB_ROOT_USER_SQL'@'%' IDENTIFIED BY '$DB_ROOT_PASS_SQL';
+GRANT ALL PRIVILEGES ON *.* TO '$DB_ROOT_USER_SQL'@'%' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
+SQLEOF

--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -39,12 +39,20 @@ docker run -d \
   -e MYSQL_ROOT_PASSWORD="$DB_ROOT_PASS" \
   mysql:8.4
 
+MYSQL_READY=false
 for i in $(seq 1 30); do
   if docker exec mysql-server mysqladmin ping -uroot -p"$DB_ROOT_PASS" 2>/dev/null; then
+    MYSQL_READY=true
     break
   fi
   sleep 2
 done
+
+if [ "$MYSQL_READY" != "true" ]; then
+  echo "MySQL container did not become ready within 60 seconds." >&2
+  docker logs --tail 100 mysql-server >&2 || true
+  exit 1
+fi
 
 docker exec -i mysql-server mysql -uroot -p"$DB_ROOT_PASS" <<SQLEOF
 CREATE USER IF NOT EXISTS '$DB_ROOT_USER_SQL'@'%' IDENTIFIED BY '$DB_ROOT_PASS_SQL';

--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -16,7 +16,7 @@ DB_ROOT_PASS_SQL="$(mysql_escape "$DB_ROOT_PASS")"
 
 command -v docker >/dev/null
 systemctl enable --now docker
-docker image inspect mysql:8.4 >/dev/null
+docker image inspect mysql:8.4.8 >/dev/null
 
 mkdir -p /var/lib/mysql
 chown -R 999:999 /var/lib/mysql
@@ -37,7 +37,7 @@ docker run -d \
   -v /var/lib/mysql:/var/lib/mysql \
   -v /etc/mysql/conf.d:/etc/mysql/conf.d \
   -e MYSQL_ROOT_PASSWORD="$DB_ROOT_PASS" \
-  mysql:8.4
+  mysql:8.4.8
 
 MYSQL_READY=false
 for i in $(seq 1 30); do

--- a/modules/app_stack/security_groups.tf
+++ b/modules/app_stack/security_groups.tf
@@ -28,7 +28,34 @@ resource "aws_security_group" "api_sg" {
   }
 }
 
-# 2. RDS용 보안 그룹 (API Server만 믿음)
+# 2. DB EC2용 보안 그룹 (API Server만 믿음)
+resource "aws_security_group" "db_ec2_sg" {
+  count       = var.enable_db_ec2 ? 1 : 0
+  name        = "sc-${var.env_name}-db-ec2-sg"
+  description = "Security Group for DB EC2"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "MySQL from API server"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.api_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "solid-connection-${var.env_name}-db-ec2-sg"
+  }
+}
+
+# 3. RDS용 보안 그룹 (API Server만 믿음)
 resource "aws_security_group" "db_sg" {
   count       = var.enable_rds ? 1 : 0
   name        = "sc-${var.env_name}-db-sg"

--- a/modules/app_stack/templates/mysql_tuning.cnf
+++ b/modules/app_stack/templates/mysql_tuning.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+max_connections          = 64
+innodb_buffer_pool_size  = 128M
+innodb_redo_log_capacity = 128M
+bind-address             = 0.0.0.0
+skip-name-resolve

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -12,6 +12,24 @@ variable "enable_rds" {
   default     = true
 }
 
+variable "enable_db_ec2" {
+  description = "DB EC2 사용 여부"
+  type        = bool
+  default     = false
+}
+
+variable "db_instance_type" {
+  description = "DB EC2 인스턴스 타입"
+  type        = string
+  default     = null
+}
+
+variable "db_ami_id" {
+  description = "DB EC2에 사용할 커스텀 AMI ID"
+  type        = string
+  default     = null
+}
+
 variable "ec2_iam_instance_profile" {
   description = "EC2에 연결할 IAM Instance Profile 이름"
   type        = string

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -30,6 +30,12 @@ variable "db_ami_id" {
   default     = null
 }
 
+variable "db_subnet_id" {
+  description = "DB EC2를 배치할 Private Subnet ID"
+  type        = string
+  default     = null
+}
+
 variable "ec2_iam_instance_profile" {
   description = "EC2에 연결할 IAM Instance Profile 이름"
   type        = string


### PR DESCRIPTION
## 관련 이슈

- resolves: #50
- parent: #39

## 작업 내용

- Prod 환경에 DB EC2 리소스를 추가했습니다.
  - 기존 RDS는 유지한 상태로 DB EC2만 추가 생성합니다.
  - DB EC2는 public IP 없이 private-only로 생성됩니다.
  - DB EC2는 `db_ec2_subnet_id`로 지정한 private subnet에 배치됩니다.
  - root EBS는 OS/bootstrap 용도로 8GB gp3 암호화 볼륨을 사용합니다.
  - API 서버 보안 그룹에서 오는 MySQL 3306 접근만 허용합니다.

- DB EC2의 MySQL 8.4 실행 방식을 추가했습니다.
  - 커스텀 AMI를 사용하도록 `db_ec2_ami_id`를 연결했습니다.
  - 커스텀 AMI에는 Docker Engine과 `mysql:8.4` 이미지가 사전 준비되어 있어야 합니다.
  - cloud-init에서 MySQL 컨테이너를 최초 실행합니다.

- MySQL 초기 튜닝 설정을 분리했습니다.
  - `modules/app_stack/templates/mysql_tuning.cnf` 파일로 튜닝 설정을 분리했습니다.
  - MySQL 8.4 기준으로 `innodb_log_file_size` 대신 `innodb_redo_log_capacity`를 사용합니다.
  - 이번 PR에서는 bootstrap 시 최초 설정 적용만 다룹니다.


- DB EC2를 Private Subnet에 명시적으로 배치하도록 변경했습니다.
  - `db_ec2_subnet_id`를 Prod 환경 변수로 추가했습니다.
  - `db_subnet_id`를 app_stack 모듈에 전달하고, DB EC2의 `subnet_id`로 사용합니다.
  - 현재 Prod API 서버와 같은 AZ(ap-northeast-2d)의 private subnet을 사용하는 전제로 구성했습니다.

- DB EC2 관련 output과 tfvars 연결을 추가했습니다.
  - `db_server_private_ip`
  - `db_server_instance_id`
  - `db_ec2_instance_type`
  - `db_ec2_ami_id`

## 특이 사항


- DB EC2는 public subnet의 public IP 미할당 방식이 아니라, 명시적으로 private subnet에 배치됩니다.
  - MySQL 3306 접근은 기존과 동일하게 API 서버 보안 그룹에서만 허용합니다.
  - `db_ec2_subnet_id` 값은 `prod.tfvars`에서 관리합니다.
  - 현재 AMI(`t4g-docker-mysql8.4-ami`)의 root snapshot이 8GB라, DB EC2 root volume도 8GB로 맞췄습니다.

- 이번 PR은 RDS를 제거하지 않습니다.
  - 기존 Prod RDS는 계속 유지됩니다.
  - 앱도 아직 기존 RDS를 바라봅니다.


- 이번 PR은 MySQL data volume 분리를 포함하지 않습니다.
  - 현재는 bootstrap 단계에서 root volume의 `/var/lib/mysql`을 사용합니다.
  - 운영 데이터 마이그레이션과 별도 EBS data volume 분리 여부는 #51/#48에서 백업/복구 전략과 함께 검토합니다.

- 이번 PR은 데이터 마이그레이션을 수행하지 않습니다.
  - 데이터 마이그레이션은 #51에서 진행합니다.
  - DB EC2가 생성된 이후, 기존 워크플로우처럼 API 서버 EC2를 경유한 SSM 포트포워딩 방식으로 DB EC2에 접근하는 방향을 검토합니다.

- 이번 PR은 `additional_db_users` 생성/권한 부여를 DB EC2에 적용하지 않습니다.
  - 기존 RDS의 추가 유저/권한 관리는 현재처럼 Terraform MySQL provider가 담당합니다.
  - DB EC2의 추가 유저/권한 부여는 DB EC2가 실제 생성된 이후 #51에서 데이터 마이그레이션과 함께 다룹니다.

- 이번 PR은 운영 중 MySQL 튜닝값 변경 반영 자동화를 포함하지 않습니다.
  - private-only DB EC2는 SSM RunCommand를 직접 사용할 수 있는 네트워크 경로가 보장되지 않습니다.
  - 따라서 튜닝값은 bootstrap 시 최초 적용만 수행합니다.
  - 운영 중 튜닝 변경 절차는 #51 이후 팀 논의를 통해 별도 작업으로 다룹니다.

- 후속 작업 흐름은 다음과 같습니다.
  - #51: RDS -> DB EC2 데이터 마이그레이션, DB EC2 접속/계정/권한 처리, datasource 전환
  - #52: 앱이 DB EC2에 정상 연결된 뒤 Prod RDS 리소스 제거
  - #48: RDS 제거 이후의 DB 백업 전략 수립
  - #49: 백업 전략 확정 이후 부하 테스트 DB 환경 전환

## 리뷰 요구사항 (선택)


- DB EC2의 private subnet 배치가 현재 Prod API 서버 접근 경로와 맞는지 확인해주세요.
- DB EC2 root volume을 8GB로 둔 것과, MySQL data volume 분리를 #51/#48 후속 논의로 넘긴 것이 적절한지 확인해주세요.


- DB EC2가 private-only로 생성되는 구성과 보안 그룹 범위를 확인해주세요.
- 커스텀 AMI 전제 조건이 적절한지 확인해주세요.
  - Ubuntu 24.04 ARM64 기반
  - Docker Engine 설치
  - `mysql:8.4` 이미지 pull 완료
  - MySQL 컨테이너 미실행
  - `/var/lib/mysql` 초기 데이터 미포함
- MySQL 튜닝값을 bootstrap 시에만 적용하고, 운영 중 변경 반영은 후속 작업으로 분리하는 방향이 적절한지 의견 부탁드립니다.
- #51에서 기존 RDS 접근 방식처럼 API 서버 EC2를 경유한 SSM 포트포워딩으로 DB EC2 계정/권한 및 마이그레이션 작업을 처리하는 방향에 대해 의견 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 운영 환경에서 EC2 기반 MySQL 데이터베이스 배포를 선택적으로 활성화하고, 배포 시 자동 초기화 및 MySQL 구동 구성을 제공합니다.
  * MySQL 튜닝 설정을 배포 과정에서 자동 적용합니다.

* **인프라 개선**
  * DB 전용 보안 그룹으로 3306/TCP 접근을 애플리케이션 측으로 제한하고, DB 인스턴스 퍼블릭 IP 비활성화 및 보안 강화를 적용합니다.
  * DB EC2의 Private IP 및 인스턴스 ID 출력값을 제공합니다.

* **보안/유지보수**
  * 운영용 비밀값 서브프로젝트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

