### PR TITLE
fix: nginx 인증서 자동 갱신 안정화

### DIFF
--- a/environment/monitoring/main.tf
+++ b/environment/monitoring/main.tf
@@ -7,20 +7,21 @@ module "monitoring_stack" {
   # 기존 app_stack 모듈을 재사용하거나, 모니터링 전용 모듈이 있다면 경로 수정
   source = "../../modules/monitoring_stack"
 
-  env_name          = "monitoring"
-  vpc_id            = data.aws_vpc.default.id
+  env_name = "monitoring"
+  vpc_id   = data.aws_vpc.default.id
 
-  ami_id            = var.ami_id
+  ami_id = var.ami_id
 
-  key_name          = var.key_name
+  key_name                 = var.key_name
+  ec2_iam_instance_profile = var.ec2_iam_instance_profile
 
-  instance_type     = var.monitoring_instance_type
+  instance_type = var.monitoring_instance_type
 
   private_ip = var.private_ip
 
   # Nginx 및 도메인 설정
-  domain_name = var.domain_name
-  cert_email  = var.cert_email
+  domain_name     = var.domain_name
+  cert_email      = var.cert_email
   nginx_conf_name = var.nginx_conf_name
 
 

--- a/environment/monitoring/variables.tf
+++ b/environment/monitoring/variables.tf
@@ -13,6 +13,11 @@ variable "key_name" {
   type        = string
 }
 
+variable "ec2_iam_instance_profile" {
+  description = "EC2 instance profile name for SSM RunCommand"
+  type        = string
+}
+
 variable "monitoring_ingress_rules" {
   description = "Ingress rules for Grafana(3000), Prometheus(9090), Loki(3100)"
   type = list(object({
@@ -26,7 +31,7 @@ variable "monitoring_ingress_rules" {
 
 variable "private_ip" {
   description = "Fixed private ip for alloy config"
-  type = string
+  type        = string
 }
 
 variable "domain_name" {

--- a/modules/app_stack/scripts/nginx_setup.sh.tftpl
+++ b/modules/app_stack/scripts/nginx_setup.sh.tftpl
@@ -6,12 +6,17 @@ set -e
 DOMAIN="${domain_name}"
 EMAIL="${email}"
 CONF_NAME="${conf_file_name}"
+CRON_NAME=$(printf '%s' "$CONF_NAME" | tr -c 'A-Za-z0-9_-' '-')
 UPSTREAM_CONF="/etc/nginx/conf.d/upstream.conf"
 CERTBOT_WEBROOT="/var/www/certbot"
 CERT_FULLCHAIN="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
 CERT_PRIVKEY="/etc/letsencrypt/live/$DOMAIN/privkey.pem"
 
 echo "Start Nginx Setup for $DOMAIN with config file: $CONF_NAME"
+
+if [ -z "$CRON_NAME" ]; then
+  CRON_NAME="nginx"
+fi
 
 reload_nginx() {
   nginx -t
@@ -151,7 +156,9 @@ upstream app_backend {
 UPSTREAM_EOF
 fi
 
+CERT_EXISTS=false
 if [ -f "$CERT_FULLCHAIN" ] && [ -f "$CERT_PRIVKEY" ]; then
+  CERT_EXISTS=true
   write_full_nginx_conf
 else
   write_http_challenge_conf
@@ -173,14 +180,16 @@ certbot certonly --webroot \
 echo "Certificate obtained successfully."
 
 # 5. Create Nginx configuration file
-write_full_nginx_conf
+if [ "$CERT_EXISTS" != "true" ]; then
+  write_full_nginx_conf
 
-# 6. Create symbolic link and remove default configuration
-ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
-rm -f /etc/nginx/sites-enabled/default
+  # 6. Create symbolic link and remove default configuration
+  ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
+  rm -f /etc/nginx/sites-enabled/default
+fi
 
 # 7. Register auto-renewal cron job
-cat <<EOF > /etc/cron.d/certbot-$CONF_NAME
+cat <<EOF > /etc/cron.d/certbot-$CRON_NAME
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/modules/app_stack/scripts/nginx_setup.sh.tftpl
+++ b/modules/app_stack/scripts/nginx_setup.sh.tftpl
@@ -7,43 +7,46 @@ DOMAIN="${domain_name}"
 EMAIL="${email}"
 CONF_NAME="${conf_file_name}"
 UPSTREAM_CONF="/etc/nginx/conf.d/upstream.conf"
+CERTBOT_WEBROOT="/var/www/certbot"
+CERT_FULLCHAIN="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
+CERT_PRIVKEY="/etc/letsencrypt/live/$DOMAIN/privkey.pem"
 
 echo "Start Nginx Setup for $DOMAIN with config file: $CONF_NAME"
 
-# 1. Install necessary packages for Nginx and Certbot
-apt-get update
-apt-get install -y nginx python3 python3-venv libaugeas0
-
-# 2. Install Certbot (using pip)
-python3 -m venv /opt/certbot/
-/opt/certbot/bin/pip install --upgrade pip
-/opt/certbot/bin/pip install certbot certbot-nginx
-ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
-
-# 3. Issue SSL certificate (Non-interactive mode)
-systemctl stop nginx
-
-certbot certonly --standalone \
-  --non-interactive \
-  --agree-tos \
-  --email "$EMAIL" \
-  -d "$DOMAIN"
-
-echo "Certificate obtained successfully."
-
-# 4. Create upstream config file only on first provisioning (initial active slot: blue on port 8080)
-# Blue-Green 배포 시 이 파일만 교체하고 nginx -s reload 로 트래픽 전환
-# 이미 존재하면 덮어쓰지 않음 — 재프로비저닝 시 현재 active 슬롯 유지
-if [ ! -f "$UPSTREAM_CONF" ]; then
-  cat <<UPSTREAM_EOF > $UPSTREAM_CONF
-upstream app_backend {
-    server 127.0.0.1:8080;
+reload_nginx() {
+  nginx -t
+  systemctl reload nginx || systemctl restart nginx
 }
-UPSTREAM_EOF
-fi
 
-# 5. Create Nginx configuration file
-cat <<EOF > /etc/nginx/sites-available/$CONF_NAME
+write_http_challenge_conf() {
+  cat <<EOF > /etc/nginx/sites-available/$CONF_NAME
+# 1차 차단: 도메인과 일치하지 않는 요청 차단 (IP 직접 접근, 알 수 없는 Host 헤더)
+# 응답 없이 연결을 즉시 종료하여 봇이 서버 존재를 인식하지 못하게 함
+server {
+    listen 80 default_server;
+    server_name _;
+    return 444;
+}
+
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root $CERTBOT_WEBROOT;
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+EOF
+}
+
+write_full_nginx_conf() {
+  cat <<EOF > /etc/nginx/sites-available/$CONF_NAME
 map \$http_upgrade \$connection_upgrade {
     default upgrade;
     ''      '';
@@ -70,8 +73,15 @@ server {
 server {
     listen 80;
     server_name $DOMAIN;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root $CERTBOT_WEBROOT;
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
     location / {
-            return 301 https://\$host\$request_uri;
+        return 301 https://\$host\$request_uri;
     }
 }
 
@@ -115,16 +125,69 @@ server {
     }
 }
 EOF
+}
+
+# 1. Install necessary packages for Nginx and Certbot
+apt-get update
+apt-get install -y nginx python3 python3-venv libaugeas0
+
+# 2. Install Certbot (using pip)
+python3 -m venv /opt/certbot/
+/opt/certbot/bin/pip install --upgrade pip
+/opt/certbot/bin/pip install certbot certbot-nginx
+ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
+
+# 3. Prepare Nginx webroot for HTTP-01 challenge
+mkdir -p "$CERTBOT_WEBROOT"
+
+# Create upstream config file only on first provisioning (initial active slot: blue on port 8080)
+# Blue-Green 배포 시 이 파일만 교체하고 nginx -s reload 로 트래픽 전환
+# 이미 존재하면 덮어쓰지 않음 — 재프로비저닝 시 현재 active 슬롯 유지
+if [ ! -f "$UPSTREAM_CONF" ]; then
+  cat <<UPSTREAM_EOF > $UPSTREAM_CONF
+upstream app_backend {
+    server 127.0.0.1:8080;
+}
+UPSTREAM_EOF
+fi
+
+if [ -f "$CERT_FULLCHAIN" ] && [ -f "$CERT_PRIVKEY" ]; then
+  write_full_nginx_conf
+else
+  write_http_challenge_conf
+fi
+
+ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
+rm -f /etc/nginx/sites-enabled/default
+reload_nginx
+
+# 4. Issue or renew SSL certificate (Non-interactive mode)
+certbot certonly --webroot \
+  --webroot-path "$CERTBOT_WEBROOT" \
+  --non-interactive \
+  --agree-tos \
+  --keep-until-expiring \
+  --email "$EMAIL" \
+  -d "$DOMAIN"
+
+echo "Certificate obtained successfully."
+
+# 5. Create Nginx configuration file
+write_full_nginx_conf
 
 # 6. Create symbolic link and remove default configuration
 ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
 rm -f /etc/nginx/sites-enabled/default
 
 # 7. Register auto-renewal cron job
-echo "0 0,12 * * * root /opt/certbot/bin/python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | tee -a /etc/crontab > /dev/null
+cat <<EOF > /etc/cron.d/certbot-$CONF_NAME
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+0 0,12 * * * root /opt/certbot/bin/python -c 'import random,time; time.sleep(random.random() * 3600)' && /usr/bin/certbot renew --webroot --webroot-path $CERTBOT_WEBROOT --quiet --deploy-hook "/usr/bin/systemctl reload nginx"
+EOF
 
 # 8. Nginx restart
-nginx -t
-systemctl restart nginx
+reload_nginx
 
 echo "Nginx setup complete!"

--- a/modules/monitoring_stack/ec2.tf
+++ b/modules/monitoring_stack/ec2.tf
@@ -1,3 +1,18 @@
+locals {
+  nginx_setup_script = templatefile("${path.module}/scripts/nginx_setup.sh.tftpl", {
+    domain_name    = var.domain_name
+    email          = var.cert_email
+    conf_file_name = var.nginx_conf_name
+  })
+
+  nginx_script_b64 = base64encode(local.nginx_setup_script)
+
+  nginx_ssm_params = jsonencode({
+    commands         = ["cloud-init status --wait > /dev/null", "echo ${local.nginx_script_b64} | base64 -d | sudo bash"]
+    executionTimeout = ["3600"]
+  })
+}
+
 data "cloudinit_config" "app_init" {
   gzip          = true
   base64_encode = true
@@ -12,17 +27,13 @@ data "cloudinit_config" "app_init" {
   # [Part 2] Nginx 설정 스크립트 파일 생성 (실행 안 함, 파일만 생성)
   part {
     content_type = "text/cloud-config"
-    content = <<EOF
+    content      = <<EOF
 write_files:
   - path: /home/ubuntu/setup_nginx.sh
     owner: ubuntu:ubuntu
     permissions: '0755'
     content: |
-${indent(6, templatefile("${path.module}/scripts/nginx_setup.sh.tftpl", {
-      domain_name    = var.domain_name
-      email          = var.cert_email
-      conf_file_name = var.nginx_conf_name
-    }))}
+${indent(6, local.nginx_setup_script)}
 EOF
   }
 }
@@ -33,6 +44,7 @@ resource "aws_instance" "monitoring_server" {
   key_name      = var.key_name
 
   associate_public_ip_address = true
+  iam_instance_profile        = var.ec2_iam_instance_profile
 
   vpc_security_group_ids = [aws_security_group.monitoring_sg.id]
 
@@ -52,5 +64,67 @@ resource "aws_instance" "monitoring_server" {
       user_data_base64,
       ami
     ]
+  }
+}
+
+resource "terraform_data" "update_nginx" {
+  count = var.ec2_iam_instance_profile == null ? 0 : 1
+
+  depends_on = [aws_instance.monitoring_server]
+
+  triggers_replace = {
+    instance_id = aws_instance.monitoring_server.id
+    script_hash = sha256(local.nginx_setup_script)
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      INSTANCE_ID='${aws_instance.monitoring_server.id}'
+      ATTEMPTS=0
+      while [ "$ATTEMPTS" -lt 60 ]; do
+        PING_STATUS=$(aws ssm describe-instance-information \
+          --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+          --query "InstanceInformationList[0].PingStatus" --output text 2>/dev/null || echo "Offline")
+        if [ "$PING_STATUS" = "Online" ]; then
+          break
+        fi
+        ATTEMPTS=$((ATTEMPTS + 1))
+        sleep 10
+      done
+      if [ "$PING_STATUS" != "Online" ]; then
+        echo "SSM agent did not become online after 600s" >&2
+        exit 1
+      fi
+
+      COMMAND_ID=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters '${local.nginx_ssm_params}' \
+        --output text \
+        --query "Command.CommandId")
+      ATTEMPTS=0
+      while [ "$ATTEMPTS" -lt 360 ]; do
+        STATUS=$(aws ssm get-command-invocation \
+          --command-id "$COMMAND_ID" \
+          --instance-id "$INSTANCE_ID" \
+          --query "Status" --output text 2>/dev/null || echo "Pending")
+        case "$STATUS" in
+          Success) exit 0 ;;
+          Failed|Cancelled|TimedOut|Undeliverable)
+            echo "SSM command $STATUS" >&2
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardErrorContent" --output text >&2
+            exit 1 ;;
+        esac
+        ATTEMPTS=$((ATTEMPTS + 1))
+        sleep 10
+      done
+      echo "SSM command timed out after 3600s" >&2
+      exit 1
+    EOT
   }
 }

--- a/modules/monitoring_stack/scripts/nginx_setup.sh.tftpl
+++ b/modules/monitoring_stack/scripts/nginx_setup.sh.tftpl
@@ -5,24 +5,24 @@ set -e
 DOMAIN="${domain_name}"
 EMAIL="${email}"
 CONF_NAME="${conf_file_name}"
+CRON_NAME=$(printf '%s' "$CONF_NAME" | tr -c 'A-Za-z0-9_-' '-')
 CERTBOT_WEBROOT="/var/www/certbot"
+CERT_FULLCHAIN="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
+CERT_PRIVKEY="/etc/letsencrypt/live/$DOMAIN/privkey.pem"
 
 echo ">>> $DOMAIN 에 대한 Nginx 및 SSL 설정을 시작합니다."
 
-# 1. 패키지 설치
-sudo apt-get update
-sudo apt-get install -y nginx python3 python3-venv libaugeas0
+if [ -z "$CRON_NAME" ]; then
+  CRON_NAME="nginx"
+fi
 
-# 2. Certbot 설치 및 링크
-sudo python3 -m venv /opt/certbot/
-sudo /opt/certbot/bin/pip install --upgrade pip
-sudo /opt/certbot/bin/pip install certbot certbot-nginx
-sudo ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
+reload_nginx() {
+  sudo nginx -t
+  sudo systemctl reload nginx || sudo systemctl restart nginx
+}
 
-# 3. HTTP-01 challenge를 nginx가 처리할 수 있도록 webroot 설정
-sudo mkdir -p "$CERTBOT_WEBROOT"
-
-sudo tee /etc/nginx/sites-available/$CONF_NAME > /dev/null <<EOF
+write_http_challenge_conf() {
+  sudo tee /etc/nginx/sites-available/$CONF_NAME > /dev/null <<EOF
 server {
     listen 80;
     server_name $DOMAIN;
@@ -38,23 +38,10 @@ server {
     }
 }
 EOF
+}
 
-sudo ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
-sudo rm -f /etc/nginx/sites-enabled/default
-sudo nginx -t
-sudo systemctl reload nginx || sudo systemctl restart nginx
-
-# 4. SSL 인증서 발급/갱신
-sudo certbot certonly --webroot \
-  --webroot-path "$CERTBOT_WEBROOT" \
-  --non-interactive \
-  --agree-tos \
-  --keep-until-expiring \
-  --email "$EMAIL" \
-  -d "$DOMAIN"
-
-# 5. Nginx 설정 파일 작성
-sudo tee /etc/nginx/sites-available/$CONF_NAME > /dev/null <<EOF
+write_full_nginx_conf() {
+  sudo tee /etc/nginx/sites-available/$CONF_NAME > /dev/null <<EOF
 server {
     listen 80;
     server_name $DOMAIN;
@@ -94,13 +81,56 @@ server {
     }
 }
 EOF
+}
 
-# 6. 설정 활성화
-sudo ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
-sudo rm -f /etc/nginx/sites-enabled/default
+activate_nginx_conf() {
+  sudo ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
+  sudo rm -f /etc/nginx/sites-enabled/default
+}
+
+# 1. 패키지 설치
+sudo apt-get update
+sudo apt-get install -y nginx python3 python3-venv libaugeas0
+
+# 2. Certbot 설치 및 링크
+sudo python3 -m venv /opt/certbot/
+sudo /opt/certbot/bin/pip install --upgrade pip
+sudo /opt/certbot/bin/pip install certbot certbot-nginx
+sudo ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
+
+# 3. HTTP-01 challenge를 nginx가 처리할 수 있도록 webroot 설정
+sudo mkdir -p "$CERTBOT_WEBROOT"
+
+CERT_EXISTS=false
+if [ -f "$CERT_FULLCHAIN" ] && [ -f "$CERT_PRIVKEY" ]; then
+  CERT_EXISTS=true
+  write_full_nginx_conf
+else
+  write_http_challenge_conf
+fi
+
+activate_nginx_conf
+reload_nginx
+
+# 4. SSL 인증서 발급/갱신
+sudo certbot certonly --webroot \
+  --webroot-path "$CERTBOT_WEBROOT" \
+  --non-interactive \
+  --agree-tos \
+  --keep-until-expiring \
+  --email "$EMAIL" \
+  -d "$DOMAIN"
+
+# 5. Nginx 설정 파일 작성
+if [ "$CERT_EXISTS" != "true" ]; then
+  write_full_nginx_conf
+
+  # 6. 설정 활성화
+  activate_nginx_conf
+fi
 
 # 7. 자동 갱신 크론 등록
-sudo tee /etc/cron.d/certbot-$CONF_NAME > /dev/null <<EOF
+sudo tee /etc/cron.d/certbot-$CRON_NAME > /dev/null <<EOF
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -108,7 +138,6 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 EOF
 
 # 8. Nginx 재시작
-sudo nginx -t
-sudo systemctl reload nginx || sudo systemctl restart nginx
+reload_nginx
 
 echo "Nginx setup complete!"

--- a/modules/monitoring_stack/scripts/nginx_setup.sh.tftpl
+++ b/modules/monitoring_stack/scripts/nginx_setup.sh.tftpl
@@ -5,8 +5,9 @@ set -e
 DOMAIN="${domain_name}"
 EMAIL="${email}"
 CONF_NAME="${conf_file_name}"
+CERTBOT_WEBROOT="/var/www/certbot"
 
-echo ">>> [수동 실행] $DOMAIN 에 대한 Nginx 및 SSL 설정을 시작합니다."
+echo ">>> $DOMAIN 에 대한 Nginx 및 SSL 설정을 시작합니다."
 
 # 1. 패키지 설치
 sudo apt-get update
@@ -18,19 +19,52 @@ sudo /opt/certbot/bin/pip install --upgrade pip
 sudo /opt/certbot/bin/pip install certbot certbot-nginx
 sudo ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
-# 3. SSL 인증서 발급
-sudo systemctl stop nginx
-sudo certbot certonly --standalone \
-  --non-interactive \
-  --agree-tos \
-  --email "$EMAIL" \
-  -d "$DOMAIN"
+# 3. HTTP-01 challenge를 nginx가 처리할 수 있도록 webroot 설정
+sudo mkdir -p "$CERTBOT_WEBROOT"
 
-# 4. Nginx 설정 파일 작성
 sudo tee /etc/nginx/sites-available/$CONF_NAME > /dev/null <<EOF
 server {
     listen 80;
     server_name $DOMAIN;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root $CERTBOT_WEBROOT;
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+EOF
+
+sudo ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo nginx -t
+sudo systemctl reload nginx || sudo systemctl restart nginx
+
+# 4. SSL 인증서 발급/갱신
+sudo certbot certonly --webroot \
+  --webroot-path "$CERTBOT_WEBROOT" \
+  --non-interactive \
+  --agree-tos \
+  --keep-until-expiring \
+  --email "$EMAIL" \
+  -d "$DOMAIN"
+
+# 5. Nginx 설정 파일 작성
+sudo tee /etc/nginx/sites-available/$CONF_NAME > /dev/null <<EOF
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root $CERTBOT_WEBROOT;
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
     location / {
         return 301 https://\$host\$request_uri;
     }
@@ -61,17 +95,20 @@ server {
 }
 EOF
 
-# 5. 설정 활성화
+# 6. 설정 활성화
 sudo ln -sf /etc/nginx/sites-available/$CONF_NAME /etc/nginx/sites-enabled/$CONF_NAME
 sudo rm -f /etc/nginx/sites-enabled/default
 
-# 6. 자동 갱신 크론탭 등록
-if ! crontab -l 2>/dev/null | grep -q "certbot renew"; then
-  (crontab -l 2>/dev/null; echo "0 0,12 * * * /usr/bin/certbot renew --quiet --post-hook 'systemctl reload nginx'") | crontab -
-fi
+# 7. 자동 갱신 크론 등록
+sudo tee /etc/cron.d/certbot-$CONF_NAME > /dev/null <<EOF
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# 7. Nginx 재시작
+0 0,12 * * * root /opt/certbot/bin/python -c 'import random,time; time.sleep(random.random() * 3600)' && /usr/bin/certbot renew --webroot --webroot-path $CERTBOT_WEBROOT --quiet --deploy-hook "/usr/bin/systemctl reload nginx"
+EOF
+
+# 8. Nginx 재시작
 sudo nginx -t
-sudo systemctl restart nginx
+sudo systemctl reload nginx || sudo systemctl restart nginx
 
 echo "Nginx setup complete!"

--- a/modules/monitoring_stack/variables.tf
+++ b/modules/monitoring_stack/variables.tf
@@ -18,6 +18,12 @@ variable "key_name" {
   type        = string
 }
 
+variable "ec2_iam_instance_profile" {
+  description = "SSM RunCommand 실행을 위해 EC2에 연결할 IAM Instance Profile 이름"
+  type        = string
+  default     = null
+}
+
 variable "instance_type" {
   description = "EC2 인스턴스 타입"
   type        = string
@@ -25,7 +31,7 @@ variable "instance_type" {
 
 variable "private_ip" {
   description = "alloy 설정을 위한 private ip 고정"
-  type = string
+  type        = string
 }
 
 variable "monitoring_ingress_rules" {


### PR DESCRIPTION
## 관련 이슈

- resolves: #54

## 작업 내용

- Monitoring Nginx 인증서 발급/갱신 방식을 `standalone`에서 `webroot` 방식으로 변경했습니다.
  - certbot이 80번 포트를 직접 점유하지 않고, nginx가 `/.well-known/acme-challenge/` 요청을 처리합니다.
  - 인증서 발급/갱신 과정에서 monitoring EC2 또는 nginx를 중지하지 않도록 변경했습니다.
  - 자동 갱신 cron을 `/etc/cron.d/certbot-$CONF_NAME` 파일로 관리하도록 변경해 중복 등록을 방지했습니다.

- Monitoring EC2에 nginx 설정 변경 반영 경로를 추가했습니다.
  - `nginx_setup.sh.tftpl` 렌더링 결과의 hash를 `terraform_data.update_nginx` 트리거로 사용합니다.
  - hash 변경 시 SSM RunCommand로 기존 monitoring EC2에서 nginx setup script를 재실행합니다.
  - monitoring EC2에 SSM 전용 instance profile을 주입할 수 있도록 `ec2_iam_instance_profile` 변수를 추가했습니다.

- Prod/Stage 공용 app_stack Nginx 인증서 갱신도 동일하게 안정화했습니다.
  - `certbot --standalone`과 `systemctl stop nginx` 흐름을 제거했습니다.
  - 기존 인증서가 있으면 443 설정을 유지한 상태로 nginx reload 후 webroot certbot을 실행합니다.
  - 인증서가 없는 최초 구성 시에는 HTTP challenge용 bootstrap config를 먼저 적용합니다.
  - `null_resource.update_nginx`의 기존 script hash 기반 재실행 구조는 유지했습니다.

- Monitoring secrets submodule을 갱신했습니다.
  - monitoring 환경에서 전용 SSM instance profile을 사용하도록 tfvars를 갱신했습니다.

## 특이 사항

- 이번 변경은 EC2 destroy/recreate를 유발하지 않습니다.
- nginx 설정 반영은 정상 경로에서 `reload`로 수행되며, reload 실패 시에만 `restart` fallback을 사용합니다.
- Prod/Stage는 기존처럼 `nginx_setup.sh.tftpl` 내용이 바뀌면 script hash 변경으로 `null_resource.update_nginx`가 재실행됩니다.
- Monitoring은 이번 PR부터 `terraform_data.update_nginx`를 통해 동일한 hash 기반 재실행 구조를 갖습니다.

검증 결과:

- `bash -n modules/monitoring_stack/scripts/nginx_setup.sh.tftpl`
- `bash -n modules/app_stack/scripts/nginx_setup.sh.tftpl`
- `terraform validate` for `environment/monitoring`
- `terraform validate` for `environment/stage`
- `terraform validate` for `environment/prod`
- Monitoring plan: EC2 instance profile in-place update + `terraform_data.update_nginx` 생성
- Stage plan: `null_resource.update_nginx` script hash replacement only
- Prod plan: SSH tunnel 연결 후 full refresh plan 성공, `null_resource.update_nginx` script hash replacement only

## 리뷰 요구사항 (선택)

- webroot 방식으로 전환한 nginx challenge location이 HTTP redirect/default server 차단 로직과 충돌하지 않는지 확인해주세요.
- Monitoring 전용 SSM instance profile을 사용하는 방향이 prod/stage app instance profile과 권한 경계를 분리하는 방식으로 적절한지 확인해주세요.
- Prod/Stage에서 인증서가 이미 있는 경우 443 설정을 유지하고, 인증서가 없는 경우 bootstrap HTTP config를 사용하는 분기 흐름이 적절한지 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 모니터링 서버에 SSM RunCommand 실행용 인스턴스 프로필을 선택적으로 연결할 수 있게 됐습니다.
  * Nginx/인증서 설정을 SSM 기반 원격 적용으로 자동화했습니다.
  * 인증서 발급/갱신 방식을 웹루트 기반으로 전환해 자동 갱신 시에도 웹 구성을 안정적으로 유지합니다.
* **버그 수정**
  * Nginx 적용을 검증 후 일관된 로드/리로드 흐름으로 정리해 서비스 중단 위험을 낮췄습니다.
  * 갱신 스케줄 및 갱신 훅 설정이 개선되어 갱신 작업 안정성이 향상됐습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->