### PR TITLE
refactor: DB EC2 MySQL data volume 분리

### DIFF
--- a/environment/prod/main.tf
+++ b/environment/prod/main.tf
@@ -22,10 +22,11 @@ module "prod_stack" {
   db_instance_class = var.db_instance_class
 
   # DB EC2 설정
-  enable_db_ec2    = true
-  db_instance_type = var.db_ec2_instance_type
-  db_ami_id        = var.db_ec2_ami_id
-  db_subnet_id     = var.db_ec2_subnet_id
+  enable_db_ec2       = true
+  db_instance_type    = var.db_ec2_instance_type
+  db_ami_id           = var.db_ec2_ami_id
+  db_subnet_id        = var.db_ec2_subnet_id
+  db_data_volume_size = var.db_data_volume_size
 
   # 보안 그룹 규칙
   api_ingress_rules = var.api_ingress_rules

--- a/environment/prod/variables.tf
+++ b/environment/prod/variables.tf
@@ -33,6 +33,11 @@ variable "db_ec2_subnet_id" {
   type        = string
 }
 
+variable "db_data_volume_size" {
+  description = "DB EC2 MySQL data volume 크기 (GiB)"
+  type        = number
+}
+
 variable "api_ingress_rules" {
   description = "List of ingress rules for API Server"
   type = list(object({

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -75,9 +75,6 @@ resource "aws_instance" "db_server" {
     ignore_changes = [
       key_name,
     ]
-    replace_triggered_by = [
-      aws_ebs_volume.db_data[count.index],
-    ]
   }
 }
 

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -1,3 +1,26 @@
+data "aws_subnet" "db_ec2" {
+  count = var.enable_db_ec2 ? 1 : 0
+
+  id = var.db_subnet_id
+}
+
+resource "aws_ebs_volume" "db_data" {
+  count = var.enable_db_ec2 ? 1 : 0
+
+  availability_zone = data.aws_subnet.db_ec2[count.index].availability_zone
+  size              = var.db_data_volume_size
+  type              = "gp3"
+  encrypted         = true
+
+  tags = {
+    Name = "solid-connection-db-mysql-data-${var.env_name}"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 data "cloudinit_config" "db_init" {
   count         = var.enable_db_ec2 ? 1 : 0
   gzip          = true
@@ -8,6 +31,7 @@ data "cloudinit_config" "db_init" {
     content = templatefile("${path.module}/scripts/mysql_setup.sh.tftpl", {
       db_root_username_b64 = base64encode(var.db_username)
       db_root_password_b64 = base64encode(var.db_password)
+      db_data_volume_id    = aws_ebs_volume.db_data[count.index].id
       mysql_config_content = file("${path.module}/templates/mysql_tuning.cnf")
     })
     filename = "mysql_setup.sh"
@@ -45,14 +69,23 @@ resource "aws_instance" "db_server" {
     Name = "solid-connection-db-mysql-${var.env_name}"
   }
 
-  user_data_replace_on_change = false
+  user_data_replace_on_change = true
 
   lifecycle {
     ignore_changes = [
-      user_data,
-      user_data_base64,
-      user_data_replace_on_change,
       key_name,
     ]
+    replace_triggered_by = [
+      aws_ebs_volume.db_data[count.index],
+    ]
   }
+}
+
+resource "aws_volume_attachment" "db_data" {
+  count = var.enable_db_ec2 ? 1 : 0
+
+  device_name                    = "/dev/sdf"
+  volume_id                      = aws_ebs_volume.db_data[count.index].id
+  instance_id                    = aws_instance.db_server[count.index].id
+  stop_instance_before_detaching = true
 }

--- a/modules/app_stack/output.tf
+++ b/modules/app_stack/output.tf
@@ -7,3 +7,8 @@ output "db_server_instance_id" {
   description = "DB EC2 서버 인스턴스 ID"
   value       = try(aws_instance.db_server[0].id, null)
 }
+
+output "db_server_data_volume_id" {
+  description = "DB EC2 MySQL data volume ID"
+  value       = try(aws_ebs_volume.db_data[0].id, null)
+}

--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -25,6 +25,8 @@ docker image inspect mysql:8.4.8 >/dev/null
 DATA_VOLUME_ID="${db_data_volume_id}"
 DATA_VOLUME_SERIAL="$(printf '%s' "$DATA_VOLUME_ID" | tr -d '-')"
 DATA_VOLUME_DEVICE="/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_$DATA_VOLUME_SERIAL"
+DATA_VOLUME_MOUNT="/mnt/mysql-data"
+MYSQL_DATA_DIR="$DATA_VOLUME_MOUNT/mysql"
 
 for i in $(seq 1 120); do
   if [ -e "$DATA_VOLUME_DEVICE" ]; then
@@ -43,17 +45,22 @@ if ! blkid "$DATA_VOLUME_DEVICE" >/dev/null 2>&1; then
   mkfs.ext4 -F "$DATA_VOLUME_DEVICE"
 fi
 
-mkdir -p /var/lib/mysql
+mkdir -p "$DATA_VOLUME_MOUNT"
 DATA_VOLUME_UUID="$(blkid -s UUID -o value "$DATA_VOLUME_DEVICE")"
 
-awk '$2 != "/var/lib/mysql" { print }' /etc/fstab > /etc/fstab.tmp
-printf 'UUID=%s /var/lib/mysql ext4 defaults,nofail 0 2\n' "$DATA_VOLUME_UUID" >> /etc/fstab.tmp
+awk -v mount="$DATA_VOLUME_MOUNT" '$2 != mount { print }' /etc/fstab > /etc/fstab.tmp
+printf 'UUID=%s %s ext4 defaults,nofail 0 2\n' "$DATA_VOLUME_UUID" "$DATA_VOLUME_MOUNT" >> /etc/fstab.tmp
 mv /etc/fstab.tmp /etc/fstab
 
-mountpoint -q /var/lib/mysql || mount /var/lib/mysql
+mountpoint -q "$DATA_VOLUME_MOUNT" || mount "$DATA_VOLUME_MOUNT"
+mountpoint -q "$DATA_VOLUME_MOUNT" || {
+  echo "Failed to mount data volume $DATA_VOLUME_ID at $DATA_VOLUME_MOUNT." >&2
+  exit 1
+}
 
-chown -R 999:999 /var/lib/mysql
-chmod 750 /var/lib/mysql
+mkdir -p "$MYSQL_DATA_DIR"
+chown -R 999:999 "$MYSQL_DATA_DIR"
+chmod 750 "$MYSQL_DATA_DIR"
 
 mkdir -p /etc/mysql/conf.d
 cat > /etc/mysql/conf.d/tuning.cnf <<'CNFEOF'
@@ -67,7 +74,7 @@ docker run -d \
   --name mysql-server \
   --restart always \
   -p 3306:3306 \
-  -v /var/lib/mysql:/var/lib/mysql \
+  -v "$MYSQL_DATA_DIR:/var/lib/mysql" \
   -v /etc/mysql/conf.d:/etc/mysql/conf.d \
   -e MYSQL_ROOT_PASSWORD="$DB_ROOT_PASS" \
   mysql:8.4.8

--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -15,10 +15,43 @@ DB_ROOT_USER_SQL="$(mysql_escape "$DB_ROOT_USER")"
 DB_ROOT_PASS_SQL="$(mysql_escape "$DB_ROOT_PASS")"
 
 command -v docker >/dev/null
+command -v blkid >/dev/null
+command -v mkfs.ext4 >/dev/null
+command -v mountpoint >/dev/null
+
 systemctl enable --now docker
 docker image inspect mysql:8.4.8 >/dev/null
 
+DATA_VOLUME_ID="${db_data_volume_id}"
+DATA_VOLUME_SERIAL="$(printf '%s' "$DATA_VOLUME_ID" | tr -d '-')"
+DATA_VOLUME_DEVICE="/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_$DATA_VOLUME_SERIAL"
+
+for i in $(seq 1 120); do
+  if [ -e "$DATA_VOLUME_DEVICE" ]; then
+    break
+  fi
+  sleep 2
+done
+
+if [ ! -e "$DATA_VOLUME_DEVICE" ]; then
+  echo "Data volume $DATA_VOLUME_ID was not attached within 240 seconds." >&2
+  ls -la /dev/disk/by-id >&2 || true
+  exit 1
+fi
+
+if ! blkid "$DATA_VOLUME_DEVICE" >/dev/null 2>&1; then
+  mkfs.ext4 -F "$DATA_VOLUME_DEVICE"
+fi
+
 mkdir -p /var/lib/mysql
+DATA_VOLUME_UUID="$(blkid -s UUID -o value "$DATA_VOLUME_DEVICE")"
+
+awk '$2 != "/var/lib/mysql" { print }' /etc/fstab > /etc/fstab.tmp
+printf 'UUID=%s /var/lib/mysql ext4 defaults,nofail 0 2\n' "$DATA_VOLUME_UUID" >> /etc/fstab.tmp
+mv /etc/fstab.tmp /etc/fstab
+
+mountpoint -q /var/lib/mysql || mount /var/lib/mysql
+
 chown -R 999:999 /var/lib/mysql
 chmod 750 /var/lib/mysql
 

--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -19,8 +19,7 @@ command -v blkid >/dev/null
 command -v mkfs.ext4 >/dev/null
 command -v mountpoint >/dev/null
 
-systemctl enable --now docker
-docker image inspect mysql:8.4.8 >/dev/null
+systemctl enable docker
 
 DATA_VOLUME_ID="${db_data_volume_id}"
 DATA_VOLUME_SERIAL="$(printf '%s' "$DATA_VOLUME_ID" | tr -d '-')"
@@ -57,6 +56,16 @@ mountpoint -q "$DATA_VOLUME_MOUNT" || {
   echo "Failed to mount data volume $DATA_VOLUME_ID at $DATA_VOLUME_MOUNT." >&2
   exit 1
 }
+
+mkdir -p /etc/systemd/system/docker.service.d
+cat > /etc/systemd/system/docker.service.d/10-require-mysql-data.conf <<EOF
+[Unit]
+RequiresMountsFor=$DATA_VOLUME_MOUNT
+After=local-fs.target
+EOF
+systemctl daemon-reload
+systemctl restart docker
+docker image inspect mysql:8.4.8 >/dev/null
 
 mkdir -p "$MYSQL_DATA_DIR"
 chown -R 999:999 "$MYSQL_DATA_DIR"

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -36,6 +36,22 @@ variable "db_subnet_id" {
   default     = null
 }
 
+variable "db_data_volume_size" {
+  description = "DB EC2 MySQL data volume 크기 (GiB)"
+  type        = number
+  default     = null
+
+  validation {
+    condition     = !var.enable_db_ec2 || var.db_data_volume_size != null
+    error_message = "enable_db_ec2가 true이면 db_data_volume_size를 지정해야 합니다."
+  }
+
+  validation {
+    condition     = var.db_data_volume_size == null || var.db_data_volume_size >= 1
+    error_message = "db_data_volume_size는 1GiB 이상이어야 합니다."
+  }
+}
+
 variable "ec2_iam_instance_profile" {
   description = "EC2에 연결할 IAM Instance Profile 이름"
   type        = string

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -47,7 +47,7 @@ variable "db_data_volume_size" {
   }
 
   validation {
-    condition     = var.db_data_volume_size == null || var.db_data_volume_size >= 1
+    condition     = var.db_data_volume_size == null ? true : var.db_data_volume_size >= 1
     error_message = "db_data_volume_size는 1GiB 이상이어야 합니다."
   }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #57
- sub-issue of: #39

## 작업 내용

- DB EC2의 MySQL 데이터 디렉터리(`/var/lib/mysql`)를 root volume에서 분리하기 위해 별도 EBS data volume을 추가했습니다.
- data volume은 DB EC2와 같은 AZ에 생성되며, `gp3`, encrypted, `prevent_destroy` 설정을 적용했습니다.
- bootstrap 스크립트에서 EBS volume을 감지한 뒤 ext4 포맷, `/var/lib/mysql` 마운트, `/etc/fstab` 등록을 수행하도록 수정했습니다.
- prod에서는 `db_data_volume_size` 값을 tfvars에서 주입하도록 연결했습니다.

## 특이 사항

- 현재 RDS 실사용량은 약 1.9GiB 수준이라, `root 8GiB + data 12GiB = 총 20GiB` 구성으로 기존 RDS allocated storage와 총량을 맞췄습니다.
- 이번 작업은 아직 prod 데이터 마이그레이션 전이므로 DB EC2 재생성을 전제로 진행합니다. 기존 DB EC2는 수동 종료해두었고, apply 시 Terraform이 새 DB EC2와 data volume을 생성하는 plan을 확인했습니다.
- `user_data_replace_on_change = true`는 이번 bootstrap 반영을 위한 임시 운영 상태입니다. RDS 삭제 작업(#52) 또는 운영 DB 전환 이후 PR에서 `false`로 되돌리고 `user_data`, `user_data_base64`, `user_data_replace_on_change`를 `ignore_changes`에 다시 포함할 예정입니다.

## 리뷰 요구사항 (선택)

- data volume 크기 12GiB와 `prevent_destroy` 적용 방향이 적절한지 확인 부탁드립니다.
- bootstrap에서 EBS volume을 `/var/lib/mysql`에 마운트하는 방식이 운영 전환 전 작업 흐름에 충분히 안전한지 봐주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 프로덕션 DB에 별도의 영구 데이터 볼륨을 추가했습니다.
  * DB 데이터 볼륨 크기를 GiB 단위로 설정할 수 있습니다.
  * 데이터 볼륨은 암호화되며, DB 재배포 시에도 데이터 보존을 강화했습니다.
  * DB 시작 시 저장 장치를 자동으로 준비하고 MySQL 데이터 경로에 연결합니다.

* **개선 사항**
  * 데이터 볼륨 변경 시 DB 서버가 관련 리소스와 함께 안전하게 갱신됩니다.
  * DB 데이터 볼륨 ID를 외부 설정 및 운영 과정에서 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->