### PR TITLE
hotfix: DB EC2 MySQL 초기화 OOM 방지

### DIFF
--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -18,8 +18,32 @@ command -v docker >/dev/null
 command -v blkid >/dev/null
 command -v mkfs.ext4 >/dev/null
 command -v mountpoint >/dev/null
+command -v swapon >/dev/null
+command -v mkswap >/dev/null
+
+ensure_swap() {
+  local swap_file="/swapfile"
+
+  if ! swapon --show=NAME --noheadings | grep -Fxq "$swap_file"; then
+    if [ ! -f "$swap_file" ]; then
+      fallocate -l 2G "$swap_file" || dd if=/dev/zero of="$swap_file" bs=1M count=2048
+    fi
+
+    chmod 600 "$swap_file"
+    if [ "$(blkid -s TYPE -o value "$swap_file" 2>/dev/null || true)" != "swap" ]; then
+      mkswap "$swap_file"
+    fi
+
+    swapon "$swap_file"
+  fi
+
+  if ! grep -Eq "^[^#][[:space:]]*$swap_file[[:space:]]+none[[:space:]]+swap[[:space:]]" /etc/fstab; then
+    printf '%s none swap sw 0 0\n' "$swap_file" >> /etc/fstab
+  fi
+}
 
 systemctl enable docker
+ensure_swap
 
 DATA_VOLUME_ID="${db_data_volume_id}"
 DATA_VOLUME_SERIAL="$(printf '%s' "$DATA_VOLUME_ID" | tr -d '-')"


### PR DESCRIPTION
## 관련 이슈

- 

## 작업 내용

- DB EC2 bootstrap 과정에서 MySQL 컨테이너 실행 전에 `/swapfile` 2GiB를 생성하고 활성화하도록 수정했습니다.
- 이미 swap이 활성화되어 있거나 `/swapfile`이 존재하는 경우 중복 생성하지 않도록 처리했습니다.
- 재부팅 후에도 swap이 유지되도록 `/etc/fstab`에 등록합니다.

## 특이 사항

- prod DB EC2에서 `mysql:8.4.8` 초기화 중 `mysqld`가 OOM으로 종료되며 컨테이너가 정상 기동하지 못하는 문제가 확인되어 반영한 hotfix입니다.
- swap은 root volume 내부 파일로 생성되며, 별도 EBS 리소스를 추가하지 않습니다.
- 현재 마이그레이션 전 깨진 DB EC2/data volume은 수동 삭제 및 Terraform state 정리가 완료되어, apply 시 새 DB EC2와 새 data volume이 생성되는 plan을 확인했습니다.

## 리뷰 요구사항 (선택)

- `t4g.nano` 환경에서 MySQL 8.4.8 초기화 안정성을 위해 2GiB swap을 두는 방향이 적절한지 확인 부탁드립니다.
- 검증: `bash -n modules/app_stack/scripts/mysql_setup.sh.tftpl`, `git diff --check`, prod `terraform plan` 확인 완료 (`Plan: 3 to add, 0 to change, 0 to destroy`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Docker 시작 전에 스왑 파일을 자동으로 확인하고 활성화하도록 개선했습니다.
  * 스왑 파일이 없으면 자동으로 생성하고, 시스템 재부팅 후에도 유지되도록 설정합니다.
  * 스왑 관련 명령을 사전 점검하여 초기화 과정의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->