### PR TITLE
hotfix: MySQL 초기화 완료 판정 로직 수정

### DIFF
--- a/modules/app_stack/scripts/mysql_setup.sh.tftpl
+++ b/modules/app_stack/scripts/mysql_setup.sh.tftpl
@@ -113,8 +113,8 @@ docker run -d \
   mysql:8.4.8
 
 MYSQL_READY=false
-for i in $(seq 1 30); do
-  if docker exec mysql-server mysqladmin ping -uroot -p"$DB_ROOT_PASS" 2>/dev/null; then
+for i in $(seq 1 90); do
+  if docker exec mysql-server mysql -uroot -p"$DB_ROOT_PASS" -e "SELECT 1" >/dev/null 2>&1; then
     MYSQL_READY=true
     break
   fi
@@ -122,7 +122,7 @@ for i in $(seq 1 30); do
 done
 
 if [ "$MYSQL_READY" != "true" ]; then
-  echo "MySQL container did not become ready within 60 seconds." >&2
+  echo "MySQL container did not become ready for authenticated root queries within 180 seconds." >&2
   docker logs --tail 100 mysql-server >&2 || true
   exit 1
 fi


### PR DESCRIPTION
## 관련 이슈

- 

## 작업 내용

- DB EC2 bootstrap의 MySQL readiness check를 `mysqladmin ping`에서 root 인증 기반 쿼리 실행으로 변경했습니다.
- MySQL 초기화 시간이 길어지는 경우를 고려해 대기 시간을 60초에서 180초로 늘렸습니다.
- 인증 가능한 상태가 된 뒤 `scadmin` 유저 생성 SQL이 실행되도록 순서를 보강했습니다.

## 특이 사항

문제 원인은 `mysqladmin ping`이 MySQL 서버 프로세스 응답 여부만으로 성공할 수 있어, root 인증이 아직 가능한 상태가 아닌데도 bootstrap이 다음 단계로 넘어간 점이었습니다. 이 때문에 `CREATE USER` 실행 시점에 `ERROR 1045 (28000): Access denied for user 'root'@'localhost'`가 발생했고, cloud-init final stage가 실패했습니다.

변경 후에는 `mysql -uroot -p... -e "SELECT 1"`이 성공해야만 준비 완료로 판단하므로, root 인증과 쿼리 실행이 모두 가능한 상태에서 유저 생성이 진행됩니다.

## 리뷰 요구사항 (선택)

- root 인증 기반 readiness check로 변경한 방향이 bootstrap 안정성 측면에서 적절한지 확인 부탁드립니다.
- 검증: `bash -n modules/app_stack/scripts/mysql_setup.sh.tftpl`, `git diff --check`, prod `terraform plan` 확인 완료 (`Plan: 2 to add, 0 to change, 2 to destroy`).