### PR TITLE
refactor: DB EC2 전환을 위한 DB 유저 관리 대상 변경

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -135,7 +135,7 @@ jobs:
           sudo dpkg -i /tmp/session-manager-plugin.deb
           echo "/usr/local/sessionmanagerplugin/bin" >> $GITHUB_PATH
           /usr/local/sessionmanagerplugin/bin/session-manager-plugin --version
-      - name: Start SSM Tunnel to RDS
+      - name: Start SSM Tunnel to DB EC2
         run: |
           echo "=== session-manager-plugin 진단 ==="
           which session-manager-plugin || echo "NOT IN PATH"
@@ -147,25 +147,26 @@ jobs:
             --query 'Reservations[0].Instances[0].InstanceId' \
             --output text)
 
-          RDS_HOST=$(aws rds describe-db-instances \
-            --query 'DBInstances[?contains(DBInstanceIdentifier, `prod`)].Endpoint.Address | [0]' \
+          DB_EC2_HOST=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=solid-connection-db-mysql-prod" "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].PrivateIpAddress' \
             --output text)
 
           if [ -z "$EC2_ID" ] || [ "$EC2_ID" = "None" ]; then
             echo "::error::prod EC2 인스턴스를 찾을 수 없습니다"
             exit 1
           fi
-          if [ -z "$RDS_HOST" ] || [ "$RDS_HOST" = "None" ]; then
-            echo "::error::prod RDS 엔드포인트를 찾을 수 없습니다"
+          if [ -z "$DB_EC2_HOST" ] || [ "$DB_EC2_HOST" = "None" ]; then
+            echo "::error::prod DB EC2 private IP를 찾을 수 없습니다"
             exit 1
           fi
 
-          echo "Tunneling via $EC2_ID -> $RDS_HOST:3306"
+          echo "Tunneling via $EC2_ID -> $DB_EC2_HOST:3306"
 
           aws ssm start-session \
             --target "$EC2_ID" \
             --document-name AWS-StartPortForwardingSessionToRemoteHost \
-            --parameters "{\"host\":[\"$RDS_HOST\"],\"portNumber\":[\"3306\"],\"localPortNumber\":[\"3306\"]}" &
+            --parameters "{\"host\":[\"$DB_EC2_HOST\"],\"portNumber\":[\"3306\"],\"localPortNumber\":[\"3306\"]}" &
           SSM_PID=$!
           echo "SSM_PID=$SSM_PID" >> $GITHUB_ENV
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -202,7 +202,7 @@ jobs:
           # 이후 모든 스텝의 PATH 맨 앞에 신규 설치 경로 추가
           echo "/usr/local/sessionmanagerplugin/bin" >> $GITHUB_PATH
           /usr/local/sessionmanagerplugin/bin/session-manager-plugin --version
-      - name: Start SSM Tunnel to RDS
+      - name: Start SSM Tunnel to DB EC2
         run: |
           echo "=== session-manager-plugin 진단 ==="
           which session-manager-plugin || echo "NOT IN PATH"
@@ -214,25 +214,26 @@ jobs:
             --query 'Reservations[0].Instances[0].InstanceId' \
             --output text)
 
-          RDS_HOST=$(aws rds describe-db-instances \
-            --query 'DBInstances[?contains(DBInstanceIdentifier, `prod`)].Endpoint.Address | [0]' \
+          DB_EC2_HOST=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=solid-connection-db-mysql-prod" "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].PrivateIpAddress' \
             --output text)
 
           if [ -z "$EC2_ID" ] || [ "$EC2_ID" = "None" ]; then
             echo "::error::prod EC2 인스턴스를 찾을 수 없습니다"
             exit 1
           fi
-          if [ -z "$RDS_HOST" ] || [ "$RDS_HOST" = "None" ]; then
-            echo "::error::prod RDS 엔드포인트를 찾을 수 없습니다"
+          if [ -z "$DB_EC2_HOST" ] || [ "$DB_EC2_HOST" = "None" ]; then
+            echo "::error::prod DB EC2 private IP를 찾을 수 없습니다"
             exit 1
           fi
 
-          echo "Tunneling via $EC2_ID -> $RDS_HOST:3306"
+          echo "Tunneling via $EC2_ID -> $DB_EC2_HOST:3306"
 
           aws ssm start-session \
             --target "$EC2_ID" \
             --document-name AWS-StartPortForwardingSessionToRemoteHost \
-            --parameters "{\"host\":[\"$RDS_HOST\"],\"portNumber\":[\"3306\"],\"localPortNumber\":[\"3306\"]}" &
+            --parameters "{\"host\":[\"$DB_EC2_HOST\"],\"portNumber\":[\"3306\"],\"localPortNumber\":[\"3306\"]}" &
           SSM_PID=$!
           echo "SSM_PID=$SSM_PID" >> $GITHUB_ENV
 
@@ -433,4 +434,3 @@ jobs:
       - name: Plan Status Check
         if: steps.plan.outputs.exitcode == '1'
         run: exit 1
-

--- a/modules/app_stack/db_ec2.tf
+++ b/modules/app_stack/db_ec2.tf
@@ -69,11 +69,14 @@ resource "aws_instance" "db_server" {
     Name = "solid-connection-db-mysql-${var.env_name}"
   }
 
-  user_data_replace_on_change = true
+  user_data_replace_on_change = false
 
   lifecycle {
     ignore_changes = [
       key_name,
+      user_data,
+      user_data_base64,
+      user_data_replace_on_change,
     ]
   }
 }

--- a/modules/app_stack/rds.tf
+++ b/modules/app_stack/rds.tf
@@ -24,18 +24,21 @@ resource "aws_db_instance" "default" {
 
 # 6. MySQL 추가 유저 생성
 resource "mysql_user" "users" {
-  for_each = var.enable_rds ? var.additional_db_users : {}
+  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
 
   user               = each.key
   host               = "%"
   plaintext_password = each.value.password
 
-  depends_on = [aws_db_instance.default]
+  depends_on = [
+    aws_db_instance.default,
+    aws_instance.db_server,
+  ]
 }
 
 # 7. MySQL 권한 부여
 resource "mysql_grant" "user_grants" {
-  for_each = var.enable_rds ? var.additional_db_users : {}
+  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
 
   user       = each.key
   host       = "%"


### PR DESCRIPTION
## 관련 이슈

- resolves: #52
- 후속 작업: #61

## 작업 내용

- prod Terraform plan/apply workflow의 MySQL provider 터널 대상을 RDS에서 DB EC2로 변경했습니다.
- `additional_db_users`가 DB EC2 사용 시에도 `mysql_user`, `mysql_grant`로 관리되도록 수정했습니다.
- DB EC2 `user_data` 변경이 인스턴스 재생성을 유발하지 않도록 `user_data_replace_on_change`와 `ignore_changes`를 정리했습니다.

## 특이 사항

- 이번 PR에서는 RDS를 삭제하지 않습니다.
- RDS 삭제는 앱 전환과 smoke test 이후 #61에서 별도로 진행합니다. 수동 스냅샷을 이미 생성해둔 상태에서, 삭제 작업은 후속 PR로 분리해 더 안전하게 처리합니다.
- 현재 prod plan 기준으로 RDS/DB EC2 삭제 없이 `scapp_user`, `scapp_flyway` 유저와 권한 생성만 잡히는 것을 확인했습니다.

## 리뷰 요구사항 (선택)

- workflow가 API server를 경유해 DB EC2 private IP로 터널링하는 방식이 기존 협업 워크플로우와 맞는지 확인 부탁드립니다.
- `additional_db_users`를 `enable_rds || enable_db_ec2` 조건으로 관리하는 방향이 적절한지 확인 부탁드립니다.
- 검증: `terraform fmt -check -recursive environment/prod modules/app_stack`, `git diff --check`, DB EC2 터널 기준 prod `terraform plan` 확인 완료 (`Plan: 4 to add, 0 to change, 0 to destroy`).