### PR TITLE
refactor: prod RDS 리소스 제거

### DIFF
--- a/environment/prod/variables.tf
+++ b/environment/prod/variables.tf
@@ -92,6 +92,7 @@ variable "additional_db_users" {
     database   = string
     privileges = list(string)
   }))
+  sensitive = true
 }
 
 variable "key_name" {

--- a/environment/stage/main.tf
+++ b/environment/stage/main.tf
@@ -20,9 +20,6 @@ module "stage_stack" {
   # 인스턴스 스펙
   instance_type = var.server_instance_type
 
-  # RDS 미사용 (Docker container로 대체)
-  enable_rds = false
-
   # 보안 그룹 규칙
   api_ingress_rules = var.api_ingress_rules
 

--- a/modules/app_stack/db_users.tf
+++ b/modules/app_stack/db_users.tf
@@ -1,9 +1,13 @@
+locals {
+  db_user_names = var.enable_rds || var.enable_db_ec2 ? toset(nonsensitive(keys(var.additional_db_users))) : toset([])
+}
+
 resource "mysql_user" "users" {
-  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
+  for_each = local.db_user_names
 
   user               = each.key
   host               = "%"
-  plaintext_password = each.value.password
+  plaintext_password = var.additional_db_users[each.key].password
 
   depends_on = [
     aws_db_instance.default,
@@ -12,12 +16,12 @@ resource "mysql_user" "users" {
 }
 
 resource "mysql_grant" "user_grants" {
-  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
+  for_each = local.db_user_names
 
   user       = each.key
   host       = "%"
-  database   = each.value.database
-  privileges = each.value.privileges
+  database   = var.additional_db_users[each.key].database
+  privileges = var.additional_db_users[each.key].privileges
 
   depends_on = [mysql_user.users]
 }

--- a/modules/app_stack/db_users.tf
+++ b/modules/app_stack/db_users.tf
@@ -1,0 +1,23 @@
+resource "mysql_user" "users" {
+  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
+
+  user               = each.key
+  host               = "%"
+  plaintext_password = each.value.password
+
+  depends_on = [
+    aws_db_instance.default,
+    aws_instance.db_server,
+  ]
+}
+
+resource "mysql_grant" "user_grants" {
+  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
+
+  user       = each.key
+  host       = "%"
+  database   = each.value.database
+  privileges = each.value.privileges
+
+  depends_on = [mysql_user.users]
+}

--- a/modules/app_stack/rds.tf
+++ b/modules/app_stack/rds.tf
@@ -1,4 +1,3 @@
-# 5. RDS
 resource "aws_db_instance" "default" {
   count = var.enable_rds ? 1 : 0
 
@@ -20,30 +19,4 @@ resource "aws_db_instance" "default" {
   tags = {
     Name = var.rds_identifier
   }
-}
-
-# 6. MySQL 추가 유저 생성
-resource "mysql_user" "users" {
-  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
-
-  user               = each.key
-  host               = "%"
-  plaintext_password = each.value.password
-
-  depends_on = [
-    aws_db_instance.default,
-    aws_instance.db_server,
-  ]
-}
-
-# 7. MySQL 권한 부여
-resource "mysql_grant" "user_grants" {
-  for_each = var.enable_rds || var.enable_db_ec2 ? var.additional_db_users : {}
-
-  user       = each.key
-  host       = "%"
-  database   = each.value.database
-  privileges = each.value.privileges
-
-  depends_on = [mysql_user.users]
 }

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -107,7 +107,8 @@ variable "additional_db_users" {
     database   = string
     privileges = list(string)
   }))
-  default = {}
+  sensitive = true
+  default   = {}
 }
 
 variable "db_engine_version" {

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -9,7 +9,7 @@ variable "instance_type" {
 variable "enable_rds" {
   description = "RDS 사용 여부"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "enable_db_ec2" {


### PR DESCRIPTION
## 관련 이슈

- resolves: #61

## 작업 내용

- `enable_rds` 기본값을 `false`로 변경했습니다.
- stage/prod에서 중복으로 주입하던 `enable_rds = false` 설정을 제거했습니다.
- DB 유저/권한 리소스를 `rds.tf`에서 `db_users.tf`로 분리했습니다.
- prod 환경에서 기존 RDS와 RDS 보안그룹만 destroy되도록 정리했습니다.

## 특이 사항

- `rds.tf`는 남겨두었습니다. 아직 Terraform state에 prod RDS 리소스가 남아 있으므로, 파일을 바로 제거하기보다 `enable_rds = false`를 통해 Terraform이 RDS와 RDS 보안그룹을 정상 destroy하도록 유지하는 편이 안전합니다.
- RDS 삭제 전 수동 스냅샷은 생성 완료된 상태입니다.
- 애플리케이션 datasource는 이미 DB EC2로 전환되어 정상 기동을 확인했습니다.

## 리뷰 요구사항 (선택)

- RDS 삭제 plan이 의도대로 RDS와 RDS 보안그룹만 대상으로 하는지 확인 부탁드립니다.
- 검증: `terraform fmt -check -recursive environment/prod environment/stage modules/app_stack`, `git diff --check`, stage/prod `terraform validate`, DB EC2 터널 기준 prod `terraform plan` 확인 완료 (`Plan: 0 to add, 0 to change, 2 to destroy`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 데이터베이스 사용자와 권한을 추가로 구성할 수 있습니다.
  * 별도 설정이 없는 경우 DB용 EC2가 기본적으로 비활성화됩니다.
  * 데이터베이스 환경 구성 방식이 변경되어 기존 환경 설정에 따라 RDS 사용 여부가 결정됩니다.
  * 기본 제공되던 RDS 인스턴스 및 관련 자동 사용자 설정은 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->