### PR TITLE
feat: Prod MySQL S3 백업 인프라 구성

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -199,6 +199,7 @@ jobs:
         run: |
           terraform apply -auto-approve \
             -var-file="../../config/secrets/prod.tfvars" \
+            -var-file="../../config/secrets/prod_db.tfvars" \
             -var-file="../../config/secrets/app_stack.tfvars"
       - name: Stop SSM Tunnel
         if: always()

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -267,6 +267,7 @@ jobs:
         run: |
           terraform plan -no-color \
             -var-file="../../config/secrets/prod.tfvars" \
+            -var-file="../../config/secrets/prod_db.tfvars" \
             -var-file="../../config/secrets/app_stack.tfvars" \
             2>&1 | tee plan_output.txt
           echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ modules/shared_resources/dist/*.zip
 # --- IDE & OS ---
 .idea/
 .DS_Store
+
+# --- AGENTS ---
+AGENTS.local.md

--- a/environment/prod/main.tf
+++ b/environment/prod/main.tf
@@ -29,8 +29,9 @@ module "prod_stack" {
   db_data_volume_size = var.db_data_volume_size
 
   # 보안 그룹 규칙
-  api_ingress_rules = var.api_ingress_rules
-  db_ingress_rules  = var.db_ingress_rules
+  api_ingress_rules    = var.api_ingress_rules
+  rds_ingress_rules    = var.rds_ingress_rules
+  db_ec2_ingress_rules = var.db_ec2_ingress_rules
 
   # RDS 식별자 설정
   rds_identifier = var.rds_identifier

--- a/environment/prod/mysql_backup.tf
+++ b/environment/prod/mysql_backup.tf
@@ -1,0 +1,173 @@
+resource "aws_s3_bucket" "mysql_backup" {
+  bucket              = var.mysql_backup_bucket_name
+  force_destroy       = false
+  object_lock_enabled = true
+
+  tags = {
+    Name = var.mysql_backup_bucket_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.mysql_backup.arn,
+          "${aws_s3_bucket.mysql_backup.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  depends_on = [aws_s3_bucket_versioning.mysql_backup]
+
+  rule {
+    default_retention {
+      mode = "GOVERNANCE"
+      days = 14
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "mysql_backup" {
+  bucket = aws_s3_bucket.mysql_backup.id
+
+  depends_on = [
+    aws_s3_bucket_versioning.mysql_backup,
+    aws_s3_bucket_object_lock_configuration.mysql_backup,
+  ]
+
+  rule {
+    id     = "expire-mysql-backups-after-14-days"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 14
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+
+  rule {
+    id     = "remove-expired-delete-markers"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+
+# S3 Gateway Endpoint에는 별도 시간당 또는 데이터 처리 비용이 없습니다.
+# 접근 권한은 Terraform에 선언하지 않고 수동으로 관리하는 IAM 정책에서 제한합니다.
+data "aws_route_table" "db_ec2" {
+  subnet_id = var.db_ec2_subnet_id
+}
+
+resource "aws_vpc_endpoint" "mysql_backup_s3" {
+  vpc_id            = data.aws_vpc.default.id
+  service_name      = "com.amazonaws.ap-northeast-2.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [data.aws_route_table.db_ec2.id]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowBackupBucketMetadataAccess"
+        Effect    = "Allow"
+        Principal = "*"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:ListBucketVersions",
+        ]
+        Resource = aws_s3_bucket.mysql_backup.arn
+      },
+      {
+        Sid       = "AllowBackupObjectAccess"
+        Effect    = "Allow"
+        Principal = "*"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+        ]
+        Resource = "${aws_s3_bucket.mysql_backup.arn}/*"
+      },
+    ]
+  })
+
+  tags = {
+    Name = "solid-connection-prod-mysql-backup-s3"
+  }
+}

--- a/environment/prod/outputs.tf
+++ b/environment/prod/outputs.tf
@@ -1,0 +1,9 @@
+output "mysql_backup_bucket_name" {
+  description = "Prod MySQL 백업 S3 버킷 이름"
+  value       = aws_s3_bucket.mysql_backup.bucket
+}
+
+output "mysql_backup_s3_vpc_endpoint_id" {
+  description = "Prod MySQL 백업용 S3 Gateway VPC Endpoint ID"
+  value       = aws_vpc_endpoint.mysql_backup_s3.id
+}

--- a/environment/prod/variables.tf
+++ b/environment/prod/variables.tf
@@ -38,6 +38,11 @@ variable "db_data_volume_size" {
   type        = number
 }
 
+variable "mysql_backup_bucket_name" {
+  description = "Prod MySQL dump와 binlog를 보관할 S3 버킷 이름"
+  type        = string
+}
+
 variable "api_ingress_rules" {
   description = "List of ingress rules for API Server"
   type = list(object({
@@ -49,8 +54,18 @@ variable "api_ingress_rules" {
   }))
 }
 
-variable "db_ingress_rules" {
-  description = "List of ingress rules for DB Server"
+variable "rds_ingress_rules" {
+  description = "API Server Security Group에서 RDS로 허용할 ingress 규칙"
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    description = string
+  }))
+}
+
+variable "db_ec2_ingress_rules" {
+  description = "API Server Security Group에서 DB EC2로 허용할 ingress 규칙"
   type = list(object({
     from_port   = number
     to_port     = number

--- a/modules/app_stack/security_groups.tf
+++ b/modules/app_stack/security_groups.tf
@@ -35,12 +35,15 @@ resource "aws_security_group" "db_ec2_sg" {
   description = "Security Group for DB EC2"
   vpc_id      = var.vpc_id
 
-  ingress {
-    description     = "MySQL from API server"
-    from_port       = 3306
-    to_port         = 3306
-    protocol        = "tcp"
-    security_groups = [aws_security_group.api_sg.id]
+  dynamic "ingress" {
+    for_each = var.db_ec2_ingress_rules
+    content {
+      description     = ingress.value.description
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      security_groups = [aws_security_group.api_sg.id]
+    }
   }
 
   egress {
@@ -63,7 +66,7 @@ resource "aws_security_group" "db_sg" {
   vpc_id      = var.vpc_id
 
   dynamic "ingress" {
-    for_each = var.db_ingress_rules
+    for_each = var.rds_ingress_rules
     content {
       description     = ingress.value.description
       from_port       = ingress.value.from_port

--- a/modules/app_stack/variables.tf
+++ b/modules/app_stack/variables.tf
@@ -74,8 +74,19 @@ variable "api_ingress_rules" {
   }))
 }
 
-variable "db_ingress_rules" {
-  description = "List of ingress rules for DB Server"
+variable "rds_ingress_rules" {
+  description = "API Server Security Group에서 RDS로 허용할 ingress 규칙"
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    description = string
+  }))
+  default = []
+}
+
+variable "db_ec2_ingress_rules" {
+  description = "API Server Security Group에서 DB EC2로 허용할 ingress 규칙"
   type = list(object({
     from_port   = number
     to_port     = number


### PR DESCRIPTION
## 관련 이슈

- Refs #66
- 다음 작업: DB EC2에서 mysqldump와 binlog를 S3로 전송하는 백업 스크립트 및 systemd timer를 구성합니다.

## 작업 내용

- Prod MySQL 백업 데이터를 보관할 S3 버킷과 14일 보존 정책을 구성했습니다.
- 퍼블릭 접근 차단, HTTPS 강제, SSE-S3 암호화, Versioning, Object Lock을 적용했습니다.
- Private Subnet의 DB EC2가 추가 고정비 없이 S3에 접근하도록 Gateway Endpoint를 구성하고 접근 범위를 백업 버킷으로 제한했습니다.
- API Server Security Group에서 DB EC2의 MySQL 및 SSH 포트에 접근할 수 있도록 규칙을 분리했습니다.

## 특이 사항

- RDS용 규칙임을 명확히 하기 위해 `db_ingress_rules`를 `rds_ingress_rules`로 변경했습니다.
- Terraform plan 결과는 9개 생성, 0개 변경, 0개 삭제입니다.

## 리뷰 요구사항 (선택)

- S3 보존 정책과 Gateway Endpoint의 최소 권한 범위를 중점적으로 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 프로덕션 MySQL 백업을 위한 암호화된 S3 저장소와 VPC 전용 연결을 추가했습니다.
  - 백업 데이터의 버전 관리, 보존 기간 및 자동 정리 정책을 적용했습니다.
  - 백업 저장소 이름과 연결 정보를 확인할 수 있는 출력값을 제공합니다.

- **개선 사항**
  - 프로덕션 데이터베이스 접근 규칙을 RDS와 DB 서버별로 구분해 더욱 세밀하게 설정할 수 있습니다.
  - 프로덕션 배포 및 사전 검증 과정에서 데이터베이스 관련 설정이 함께 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->